### PR TITLE
Add missing N.levels information from overview to metadata files

### DIFF
--- a/metadata/Agreement.yaml
+++ b/metadata/Agreement.yaml
@@ -8,6 +8,7 @@ VPolyagreement.Presence.v2:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VPolyagreement'
+  N.levels : 2
   N.entries : 380
   N.languages : 380
   N.missing : 31
@@ -24,6 +25,7 @@ VPolyagreement.Presence.v1:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VPolyagreement'
+  N.levels : 2
   N.entries : 368
   N.languages : 368
   N.missing : 43

--- a/metadata/Alienability.yaml
+++ b/metadata/Alienability.yaml
@@ -35,6 +35,7 @@ NPPossBoundNouns.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'NPPossBoundNouns.n'
+  N.levels : 4
   N.entries : 262
   N.languages : 262
   N.missing : 42
@@ -62,6 +63,7 @@ NPPossClassesMultiple.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPPossClassesMultiple.Presence'
+  N.levels : 2
   N.entries : 274
   N.languages : 274
   N.missing : 30
@@ -75,6 +77,7 @@ NPAlienableClasses.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'NPAlienableClasses.n'
+  N.levels : 5
   N.entries : 253
   N.languages : 253
   N.missing : 51
@@ -88,6 +91,7 @@ NPAlienableClasses.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPAlienableClasses.Presence'
+  N.levels : 2
   N.entries : 253
   N.languages : 253
   N.missing : 51
@@ -101,6 +105,7 @@ NPInalienableClasses.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'NPInalienableClasses.n'
+  N.levels : 8
   N.entries : 257
   N.languages : 257
   N.missing : 47
@@ -114,6 +119,7 @@ NPInalienableClasses.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPInalienableClasses.Presence'
+  N.levels : 2
   N.entries : 257
   N.languages : 257
   N.missing : 47
@@ -128,6 +134,7 @@ NPPossClasses.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'NPPossClasses.n'
+  N.levels : 10
   N.entries : 273
   N.languages : 273
   N.missing : 31
@@ -142,6 +149,7 @@ NPPossClasses.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPPossClasses.Presence'
+  N.levels : 2
   N.entries : 274
   N.languages : 274
   N.missing : 30
@@ -156,6 +164,7 @@ NPPossClassificationAny.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPPossClassificationAny.Presence'
+  N.levels : 2
   N.entries : 282
   N.languages : 282
   N.missing : 22

--- a/metadata/Alignment.yaml
+++ b/metadata/Alignment.yaml
@@ -8,6 +8,7 @@ AlignmentAequivalentS.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'AlignmentSAPTG'
+  N.levels : 2
   N.entries : 260281
   N.languages : 689
   N.missing : 0
@@ -70,6 +71,7 @@ AlignmentValClassCondition.binned.default:
   VariableType : 'condition'
   DataType : 'logical'
   VariantOf : 'AlignmentValClassCondition'
+  N.levels : 2
   N.entries : 18636
   N.languages : 688
   N.missing : 241645
@@ -167,6 +169,7 @@ AlignmentGequivalentP.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'AlignmentSAPTG'
+  N.levels : 2
   N.entries : 17245
   N.languages : 388
   N.missing : 243036
@@ -199,6 +202,7 @@ AlignmentPequivalentS.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'AlignmentSAPTG'
+  N.levels : 2
   N.entries : 260281
   N.languages : 689
   N.missing : 0
@@ -776,6 +780,7 @@ AlignmentTequivalentP.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'AlignmentSAPTG'
+  N.levels : 2
   N.entries : 17245
   N.languages : 388
   N.missing : 243036

--- a/metadata/Alignment_per_language.yaml
+++ b/metadata/Alignment_per_language.yaml
@@ -22,6 +22,7 @@ AlignmentAgrAccDegree:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'AlignmentSAPTG'
+  N.levels : 3
   N.entries : 328
   N.languages : 328
   N.missing : 361
@@ -98,6 +99,7 @@ AlignmentAgrErgDegree:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'AlignmentSAPTG'
+  N.levels : 3
   N.entries : 328
   N.languages : 328
   N.missing : 361
@@ -125,6 +127,7 @@ AlignmentCaseAccDegree:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'AlignmentSAPTG'
+  N.levels : 36
   N.entries : 646
   N.languages : 646
   N.missing : 43
@@ -197,6 +200,7 @@ AlignmentCaseErgDegree:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'AlignmentSAPTG'
+  N.levels : 29
   N.entries : 646
   N.languages : 646
   N.missing : 43
@@ -242,6 +246,7 @@ CaseSplitByPolarity.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CaseSplitByPolarity.Presence'
+  N.levels : 1
   N.entries : 646
   N.languages : 646
   N.missing : 43
@@ -255,6 +260,7 @@ AgrSplitByRef.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'AgrSplitByRef.Presence'
+  N.levels : 2
   N.entries : 646
   N.languages : 646
   N.missing : 43
@@ -268,6 +274,7 @@ CaseSplitByRef.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CaseSplitByRef.Presence'
+  N.levels : 2
   N.entries : 646
   N.languages : 646
   N.missing : 43
@@ -281,6 +288,7 @@ AgrSplitByValClass.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'AgrSplitByValClass.Presence'
+  N.levels : 2
   N.entries : 646
   N.languages : 646
   N.missing : 43
@@ -294,6 +302,7 @@ CaseSplitByValClass.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CaseSplitByValClass.Presence'
+  N.levels : 2
   N.entries : 646
   N.languages : 646
   N.missing : 43
@@ -307,6 +316,7 @@ AgrSplitByRank.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'AgrSplitByRank.Presence'
+  N.levels : 2
   N.entries : 646
   N.languages : 646
   N.missing : 43
@@ -320,6 +330,7 @@ CaseSplitByRank.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CaseSplitByRank.Presence'
+  N.levels : 2
   N.entries : 646
   N.languages : 646
   N.missing : 43
@@ -333,6 +344,7 @@ AgrSplitByCat.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'AgrSplitByCat.Presence'
+  N.levels : 2
   N.entries : 646
   N.languages : 646
   N.missing : 43
@@ -346,6 +358,7 @@ CaseSplitByCat.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CaseSplitByCat.Presence'
+  N.levels : 2
   N.entries : 646
   N.languages : 646
   N.missing : 43
@@ -360,6 +373,7 @@ AlignmentAgrMarkerAccDegree:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'AlignmentSAPTG'
+  N.levels : 72
   N.entries : 160
   N.languages : 160
   N.missing : 529
@@ -404,6 +418,7 @@ AlignmentAgrMarkerErgDegree:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'AlignmentSAPTG'
+  N.levels : 47
   N.entries : 160
   N.languages : 160
   N.missing : 529

--- a/metadata/Clause_linkage.yaml
+++ b/metadata/Clause_linkage.yaml
@@ -153,6 +153,7 @@ Finiteness:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'Finiteness'
+  N.levels : 3
   N.entries : 40
   N.languages : 15
   N.missing : 62

--- a/metadata/Clusivity.yaml
+++ b/metadata/Clusivity.yaml
@@ -8,6 +8,7 @@ InclExclAsPerson.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'InclExclAsPerson'
+  N.levels : 2
   N.entries : 427
   N.languages : 427
   N.missing : 39
@@ -21,6 +22,7 @@ InclExclAny.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'InclExclAny'
+  N.levels : 2
   N.entries : 466
   N.languages : 466
   N.missing : 0
@@ -50,6 +52,7 @@ InclExclAsMinAug.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'InclExclAsMinAug'
+  N.levels : 2
   N.entries : 424
   N.languages : 424
   N.missing : 42

--- a/metadata/GR_per_language.yaml
+++ b/metadata/GR_per_language.yaml
@@ -7,6 +7,7 @@ CoArgSensitivityAgr.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CoArgSensitivityAgr.Presence'
+  N.levels : 2
   N.entries : 166
   N.languages : 166
   N.missing : 531
@@ -21,6 +22,7 @@ VAgreement.Presence.v1:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VAgreement.Presence'
+  N.levels : 2
   N.entries : 624
   N.languages : 623
   N.missing : 73
@@ -34,6 +36,7 @@ CoArgSensitivityCase.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CoArgSensitivityCase.Presence'
+  N.levels : 2
   N.entries : 655
   N.languages : 654
   N.missing : 42

--- a/metadata/Gender.yaml
+++ b/metadata/Gender.yaml
@@ -7,6 +7,7 @@ Gender.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'Gender'
+  N.levels : 12
   N.entries : 112
   N.languages : 112
   N.missing : 206
@@ -34,6 +35,7 @@ Gender.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Gender'
+  N.levels : 2
   N.entries : 313
   N.languages : 311
   N.missing : 5

--- a/metadata/Grammatical_markers.yaml
+++ b/metadata/Grammatical_markers.yaml
@@ -38,6 +38,7 @@ Behavior.spreading.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Behavior'
+  N.levels : 2
   N.entries : 1853
   N.languages : 436
   N.missing : 3025
@@ -66,6 +67,7 @@ Coexponence.CaseNumber.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Exponence'
+  N.levels : 2
   N.entries : 345
   N.languages : 331
   N.missing : 4533
@@ -79,6 +81,7 @@ Coexponence.CaseReference.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Exponentiality'
+  N.levels : 2
   N.entries : 345
   N.languages : 331
   N.missing : 4533
@@ -152,6 +155,7 @@ Polyexponence.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Exponence'
+  N.levels : 2
   N.entries : 4331
   N.languages : 764
   N.missing : 547
@@ -165,6 +169,7 @@ Exponence.n:
   VariableType : 'data'
   DataType : 'count'
   VariantOf : 'Exponence'
+  N.levels : 6
   N.entries : 4878
   N.languages : 808
   N.missing : 0
@@ -194,6 +199,7 @@ Flexivity.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Flexivity.Presence'
+  N.levels : 2
   N.entries : 3002
   N.languages : 626
   N.missing : 1876
@@ -393,6 +399,7 @@ Fusion.isolating.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Fusion'
+  N.levels : 2
   N.entries : 3855
   N.languages : 691
   N.missing : 1023
@@ -512,6 +519,7 @@ Fusion.tonal.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Fusion'
+  N.levels : 2
   N.entries : 3855
   N.languages : 691
   N.missing : 1023
@@ -527,6 +535,7 @@ FlexivityLexical.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'FlexivityLexical.Presence'
+  N.levels : 2
   N.entries : 2961
   N.languages : 620
   N.missing : 1917
@@ -716,6 +725,7 @@ MorphemeType.Word.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'MorphemeType'
+  N.levels : 2
   N.entries : 3981
   N.languages : 712
   N.missing : 897
@@ -730,6 +740,7 @@ PersonPortmanteau.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PersonPortmanteau'
+  N.levels : 2
   N.entries : 1494
   N.languages : 160
   N.missing : 3384
@@ -758,6 +769,7 @@ Position.post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Position'
+  N.levels : 2
   N.entries : 3741
   N.languages : 673
   N.missing : 1137
@@ -947,6 +959,7 @@ Position.pre.Presence.v1:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Position'
+  N.levels : 2
   N.entries : 4015
   N.languages : 714
   N.missing : 863
@@ -962,6 +975,7 @@ Position.pre.Presence.v2:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Position'
+  N.levels : 2
   N.entries : 4015
   N.languages : 714
   N.missing : 863
@@ -975,6 +989,7 @@ Position.simul.Presence.v1:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Position'
+  N.levels : 2
   N.entries : 3761
   N.languages : 674
   N.missing : 1117
@@ -990,6 +1005,7 @@ Position.simul.Presence.v2:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Position'
+  N.levels : 2
   N.entries : 3761
   N.languages : 674
   N.missing : 1117
@@ -1098,6 +1114,7 @@ OppositionWithZero.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'OppositionWithZero.Presence'
+  N.levels : 2
   N.entries : 1533
   N.languages : 169
   N.missing : 3345

--- a/metadata/Locus_per_language.yaml
+++ b/metadata/Locus_per_language.yaml
@@ -2014,6 +2014,7 @@ LocusAandP.dm.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'LocusAandP.dm'
+  N.levels : 2
   N.entries : 330
   N.languages : 330
   N.missing : 0
@@ -2027,6 +2028,7 @@ LocusAandP.hm.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'LocusAandP.hm'
+  N.levels : 2
   N.entries : 330
   N.languages : 330
   N.missing : 0
@@ -2040,6 +2042,7 @@ LocusA.dm.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'LocusA'
+  N.levels : 2
   N.entries : 330
   N.languages : 330
   N.missing : 0
@@ -2053,6 +2056,7 @@ LocusA.hm.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'LocusA'
+  N.levels : 2
   N.entries : 330
   N.languages : 330
   N.missing : 0
@@ -2066,6 +2070,7 @@ LocusAorP.dm.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'LocusAorP.dm'
+  N.levels : 2
   N.entries : 330
   N.languages : 330
   N.missing : 0
@@ -2079,6 +2084,7 @@ LocusAorP.hm.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'LocusAorP.hm'
+  N.levels : 2
   N.entries : 330
   N.languages : 330
   N.missing : 0
@@ -2092,6 +2098,7 @@ LocusARG.dm.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'LocusARG.dm'
+  N.levels : 2
   N.entries : 330
   N.languages : 330
   N.missing : 0
@@ -2105,6 +2112,7 @@ LocusP.dm.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'LocusP'
+  N.levels : 2
   N.entries : 330
   N.languages : 330
   N.missing : 0
@@ -2118,6 +2126,7 @@ LocusP.hm.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'LocusP'
+  N.levels : 2
   N.entries : 330
   N.languages : 330
   N.missing : 0
@@ -2131,6 +2140,7 @@ LocusPOSS.dm.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'LocusPOSS'
+  N.levels : 2
   N.entries : 318
   N.languages : 318
   N.missing : 12
@@ -2144,6 +2154,7 @@ LocusPOSS.hm.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'LocusPOSS'
+  N.levels : 2
   N.entries : 318
   N.languages : 318
   N.missing : 12
@@ -2157,6 +2168,7 @@ LocusSandA.dm.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'LocusSandA.dm'
+  N.levels : 2
   N.entries : 330
   N.languages : 330
   N.missing : 0
@@ -2170,6 +2182,7 @@ LocusSandA.hm.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'LocusSandA.hm'
+  N.levels : 2
   N.entries : 330
   N.languages : 330
   N.missing : 0
@@ -2183,6 +2196,7 @@ LocusS.dm.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'LocusS'
+  N.levels : 2
   N.entries : 330
   N.languages : 330
   N.missing : 0
@@ -2196,6 +2210,7 @@ LocusS.hm.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'LocusS'
+  N.levels : 2
   N.entries : 330
   N.languages : 330
   N.missing : 0
@@ -2513,6 +2528,7 @@ LocusARG.hm.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'LocusARG.hm'
+  N.levels : 2
   N.entries : 330
   N.languages : 330
   N.missing : 0

--- a/metadata/Markers_per_language.yaml
+++ b/metadata/Markers_per_language.yaml
@@ -90,6 +90,7 @@ BehaviorCase.spreading.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'BehaviorCase'
+  N.levels : 2
   N.entries : 111
   N.languages : 111
   N.missing : 377
@@ -105,6 +106,7 @@ BehaviorNeg.spreading.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'BehaviorNeg'
+  N.levels : 1
   N.entries : 188
   N.languages : 188
   N.missing : 300
@@ -126,6 +128,7 @@ BehaviorNounPlural.spreading.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'BehaviorNounPlural'
+  N.levels : 2
   N.entries : 81
   N.languages : 81
   N.missing : 407
@@ -150,6 +153,7 @@ BehaviorTense.spreading.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'BehaviorTense'
+  N.levels : 1
   N.entries : 63
   N.languages : 63
   N.missing : 425
@@ -246,6 +250,7 @@ PolyexponentialityCase.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ExponentialityCase'
+  N.levels : 2
   N.entries : 331
   N.languages : 331
   N.missing : 157
@@ -262,6 +267,7 @@ PolyexponentialityNegation.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ExponentialityNegation'
+  N.levels : 2
   N.entries : 202
   N.languages : 202
   N.missing : 286
@@ -284,6 +290,7 @@ PolyexponentialityNounPlural.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ExponentialityNounPlural'
+  N.levels : 2
   N.entries : 188
   N.languages : 188
   N.missing : 300
@@ -308,6 +315,7 @@ PolyexponentialityTense.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ExponentialityTense'
+  N.levels : 2
   N.entries : 167
   N.languages : 167
   N.missing : 321
@@ -323,6 +331,7 @@ ExponentialityCase.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'ExponentialityCase'
+  N.levels : 5
   N.entries : 405
   N.languages : 405
   N.missing : 83
@@ -339,6 +348,7 @@ ExponentialityNegation.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'ExponentialityNegation'
+  N.levels : 5
   N.entries : 228
   N.languages : 228
   N.missing : 260
@@ -361,6 +371,7 @@ ExponentialityNounPlural.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'ExponentialityNounPlural'
+  N.levels : 5
   N.entries : 261
   N.languages : 261
   N.missing : 227
@@ -385,6 +396,7 @@ ExponentialityTense.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'ExponentialityTense'
+  N.levels : 6
   N.entries : 175
   N.languages : 175
   N.missing : 313
@@ -1007,6 +1019,7 @@ FusionCase.isolating.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'FusionCase'
+  N.levels : 2
   N.entries : 213
   N.languages : 213
   N.missing : 275
@@ -1021,6 +1034,7 @@ FusionNegation.isolating.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'FusionNegation'
+  N.levels : 2
   N.entries : 224
   N.languages : 224
   N.missing : 264
@@ -1041,6 +1055,7 @@ FusionNounPlural.isolating.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'FusionNounPlural'
+  N.levels : 2
   N.entries : 150
   N.languages : 150
   N.missing : 338
@@ -1064,6 +1079,7 @@ FusionTense.isolating.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'FusionTense'
+  N.levels : 2
   N.entries : 167
   N.languages : 167
   N.missing : 321
@@ -1236,6 +1252,7 @@ FusionCase.tonal.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'FusionCase'
+  N.levels : 2
   N.entries : 213
   N.languages : 213
   N.missing : 275
@@ -1250,6 +1267,7 @@ FusionNegation.tonal.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'FusionNegation'
+  N.levels : 1
   N.entries : 224
   N.languages : 224
   N.missing : 264
@@ -1270,6 +1288,7 @@ FusionNounPlural.tonal.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'FusionNounPlural'
+  N.levels : 1
   N.entries : 150
   N.languages : 150
   N.missing : 338
@@ -1293,6 +1312,7 @@ FusionTense.tonal.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'FusionTense'
+  N.levels : 2
   N.entries : 167
   N.languages : 167
   N.missing : 321
@@ -1372,6 +1392,7 @@ PositionCase.post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionCase'
+  N.levels : 2
   N.entries : 204
   N.languages : 204
   N.missing : 284
@@ -1386,6 +1407,7 @@ PositionNeg.post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionNeg'
+  N.levels : 2
   N.entries : 220
   N.languages : 220
   N.missing : 268
@@ -1406,6 +1428,7 @@ PositionNounPlural.post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionNounPlural'
+  N.levels : 2
   N.entries : 187
   N.languages : 187
   N.missing : 301
@@ -1429,6 +1452,7 @@ PositionTense.post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionTense'
+  N.levels : 2
   N.entries : 137
   N.languages : 137
   N.missing : 351
@@ -2005,6 +2029,7 @@ PositionCase.pre.Presence.v1:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionCase'
+  N.levels : 2
   N.entries : 237
   N.languages : 237
   N.missing : 251
@@ -2019,6 +2044,7 @@ PositionNeg.pre.Presence.v1:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionNeg'
+  N.levels : 2
   N.entries : 220
   N.languages : 220
   N.missing : 268
@@ -2039,6 +2065,7 @@ PositionNounPlural.pre.Presence.v1:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionNounPlural'
+  N.levels : 2
   N.entries : 193
   N.languages : 193
   N.missing : 295
@@ -2062,6 +2089,7 @@ PositionTense.pre.Presence.v1:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionTense'
+  N.levels : 2
   N.entries : 142
   N.languages : 142
   N.missing : 346
@@ -2077,6 +2105,7 @@ PositionCase.pre.Presence.v2:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionCase'
+  N.levels : 2
   N.entries : 237
   N.languages : 237
   N.missing : 251
@@ -2092,6 +2121,7 @@ PositionNeg.pre.Presence.v2:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionNeg'
+  N.levels : 2
   N.entries : 220
   N.languages : 220
   N.missing : 268
@@ -2113,6 +2143,7 @@ PositionNounPlural.pre.Presence.v2:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionNounPlural'
+  N.levels : 2
   N.entries : 193
   N.languages : 193
   N.missing : 295
@@ -2137,6 +2168,7 @@ PositionTense.pre.Presence.v2:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionTense'
+  N.levels : 2
   N.entries : 142
   N.languages : 142
   N.missing : 346
@@ -2151,6 +2183,7 @@ PositionCase.simul.Presence.v1:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionCase'
+  N.levels : 1
   N.entries : 205
   N.languages : 205
   N.missing : 283
@@ -2165,6 +2198,7 @@ PositionNeg.simul.Presence.v1:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionNeg'
+  N.levels : 2
   N.entries : 220
   N.languages : 220
   N.missing : 268
@@ -2185,6 +2219,7 @@ PositionNounPlural.simul.Presence.v1:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionNounPlural'
+  N.levels : 2
   N.entries : 192
   N.languages : 192
   N.missing : 296
@@ -2208,6 +2243,7 @@ PositionTense.simul.Presence.v1:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionTense'
+  N.levels : 2
   N.entries : 140
   N.languages : 140
   N.missing : 348
@@ -2223,6 +2259,7 @@ PositionCase.simul.Presence.v2:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionCase'
+  N.levels : 1
   N.entries : 205
   N.languages : 205
   N.missing : 283
@@ -2238,6 +2275,7 @@ PositionNeg.simul.Presence.v2:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionNeg'
+  N.levels : 2
   N.entries : 220
   N.languages : 220
   N.missing : 268
@@ -2259,6 +2297,7 @@ PositionNounPlural.simul.Presence.v2:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionNounPlural'
+  N.levels : 2
   N.entries : 192
   N.languages : 192
   N.missing : 296
@@ -2283,6 +2322,7 @@ PositionTense.simul.Presence.v2:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PositionTense'
+  N.levels : 2
   N.entries : 140
   N.languages : 140
   N.missing : 348

--- a/metadata/Morpheme_types.yaml
+++ b/metadata/Morpheme_types.yaml
@@ -7,6 +7,7 @@ Enclitic.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Enclitic.Presence'
+  N.levels : 2
   N.entries : 77
   N.languages : 76
   N.missing : 0
@@ -27,6 +28,7 @@ Endoclitic.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Endoclitic.Presence'
+  N.levels : 2
   N.entries : 77
   N.languages : 76
   N.missing : 0
@@ -47,6 +49,7 @@ Infix.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Infix.Presence'
+  N.levels : 2
   N.entries : 77
   N.languages : 76
   N.missing : 0
@@ -68,6 +71,7 @@ MorphemeType.n:
   VariableType : 'data'
   DataType : 'count'
   VariantOf : 'MorphemeType.n'
+  N.levels : 6
   N.entries : 77
   N.languages : 76
   N.missing : 0
@@ -89,6 +93,7 @@ PreMorpheme.n:
   VariableType : 'data'
   DataType : 'count'
   VariantOf : 'PreMorpheme.n'
+  N.levels : 5
   N.entries : 77
   N.languages : 76
   N.missing : 0
@@ -110,6 +115,7 @@ PostMorpheme.n:
   VariableType : 'data'
   DataType : 'count'
   VariantOf : 'PostMorpheme.n'
+  N.levels : 5
   N.entries : 77
   N.languages : 76
   N.missing : 0
@@ -130,6 +136,7 @@ Prefix.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Prefix.Presence'
+  N.levels : 2
   N.entries : 77
   N.languages : 76
   N.missing : 0
@@ -150,6 +157,7 @@ Proclitic.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Proclitic.Presence'
+  N.levels : 2
   N.entries : 77
   N.languages : 76
   N.missing : 0
@@ -170,6 +178,7 @@ Suffix.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Suffix.Presence'
+  N.levels : 2
   N.entries : 77
   N.languages : 76
   N.missing : 0

--- a/metadata/Morphology_per_language.yaml
+++ b/metadata/Morphology_per_language.yaml
@@ -8,6 +8,7 @@ VAgreement.Presence.v2:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VAgreement.Presence'
+  N.levels : 2
   N.entries : 791
   N.languages : 790
   N.missing : 142
@@ -22,6 +23,7 @@ Flexivity.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Flexivity.Presence'
+  N.levels : 2
   N.entries : 627
   N.languages : 626
   N.missing : 306
@@ -36,6 +38,7 @@ FlexivityLexical.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'FlexivityLexical.Presence'
+  N.levels : 2
   N.entries : 587
   N.languages : 586
   N.missing : 346
@@ -52,6 +55,7 @@ Polyexponence.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'Polyexponence.Presence'
+  N.levels : 2
   N.entries : 765
   N.languages : 764
   N.missing : 168
@@ -66,6 +70,7 @@ FlexivityNoun.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'FlexivityNoun.Presence'
+  N.levels : 2
   N.entries : 322
   N.languages : 321
   N.missing : 611
@@ -83,6 +88,7 @@ FlexivityVerb.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'FlexivityVerb.Presence'
+  N.levels : 2
   N.entries : 369
   N.languages : 368
   N.missing : 564
@@ -100,6 +106,7 @@ FlexivityLexicalNoun.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'FlexivityLexicalNoun.Presence'
+  N.levels : 2
   N.entries : 411
   N.languages : 410
   N.missing : 522
@@ -117,6 +124,7 @@ FlexivityLexicalVerb.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'FlexivityLexicalVerb.Presence'
+  N.levels : 2
   N.entries : 366
   N.languages : 365
   N.missing : 567
@@ -134,6 +142,7 @@ PolyexponenceNoun.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PolyexponenceNoun.Presence'
+  N.levels : 2
   N.entries : 436
   N.languages : 435
   N.missing : 497
@@ -150,6 +159,7 @@ PolyexponenceVerb.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'PolyexponenceVerb.Presence'
+  N.levels : 2
   N.entries : 428
   N.languages : 427
   N.missing : 505
@@ -166,6 +176,7 @@ SlotsWithZerosPost.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'SlotsWithZerosPost.n'
+  N.levels : 20
   N.entries : 105
   N.languages : 105
   N.missing : 828
@@ -182,6 +193,7 @@ SlotsWithZerosPrae.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'SlotsWithZerosPrae.n'
+  N.levels : 13
   N.entries : 77
   N.languages : 77
   N.missing : 856

--- a/metadata/NP_per_language.yaml
+++ b/metadata/NP_per_language.yaml
@@ -8,6 +8,7 @@ AdjAttrAgr.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPAgr.Presence'
+  N.levels : 2
   N.entries : 485
   N.languages : 485
   N.missing : 0
@@ -26,6 +27,7 @@ AdjAttrConstr.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPConstr.Presence'
+  N.levels : 2
   N.entries : 485
   N.languages : 485
   N.missing : 0
@@ -42,6 +44,7 @@ AdjAttrGvt.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPGvt.Presence'
+  N.levels : 2
   N.entries : 485
   N.languages : 485
   N.missing : 0
@@ -57,6 +60,7 @@ AdjAttrMarking.overt.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarking.overt'
+  N.levels : 2
   N.entries : 485
   N.languages : 485
   N.missing : 0
@@ -72,6 +76,7 @@ NPAgr.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPAgr.Presence'
+  N.levels : 2
   N.entries : 485
   N.languages : 485
   N.missing : 0
@@ -90,6 +95,7 @@ NPConstr.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPConstr.Presence'
+  N.levels : 2
   N.entries : 485
   N.languages : 485
   N.missing : 0
@@ -106,6 +112,7 @@ NPGvt.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPGvt.Presence'
+  N.levels : 2
   N.entries : 485
   N.languages : 485
   N.missing : 0
@@ -121,6 +128,7 @@ NPMarking.overt.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarking.overt'
+  N.levels : 2
   N.entries : 485
   N.languages : 485
   N.missing : 0

--- a/metadata/NP_structure.yaml
+++ b/metadata/NP_structure.yaml
@@ -80,6 +80,7 @@ NPAlienability.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPAlienabilityType'
+  N.levels : 2
   N.entries : 652
   N.languages : 307
   N.missing : 385
@@ -492,6 +493,7 @@ NPHeadSemClassSize.n:
   VariableType : 'data'
   DataType : 'count'
   VariantOf : 'NPHeadSemClassSize.n'
+  N.levels : 7
   N.entries : 1037
   N.languages : 485
   N.missing : 0
@@ -584,6 +586,7 @@ NPMarking.overt.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarking'
+  N.levels : 2
   N.entries : 824
   N.languages : 420
   N.missing : 213
@@ -702,6 +705,7 @@ NPLabel:
   VariableType : 'register'
   DataType : 'count'
   VariantOf : 'NPLabel'
+  N.levels : 1037
   N.entries : 1037
   N.languages : 485
   N.missing : 0
@@ -800,6 +804,7 @@ NPHeadSemConstraints.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraints.Presence'
+  N.levels : 2
   N.entries : 508
   N.languages : 263
   N.missing : 529

--- a/metadata/NP_structure_presence.yaml
+++ b/metadata/NP_structure_presence.yaml
@@ -7,6 +7,7 @@ NPAgrGender.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPAgrGender.Presence'
+  N.levels : 2
   N.entries : 138
   N.languages : 92
   N.missing : 882
@@ -22,6 +23,7 @@ NPAgrNumber.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPAgrNumber.Presence'
+  N.levels : 2
   N.entries : 138
   N.languages : 92
   N.missing : 882
@@ -37,6 +39,7 @@ NPAgrPerson.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPAgrPerson.Presence'
+  N.levels : 2
   N.entries : 138
   N.languages : 92
   N.missing : 882
@@ -52,6 +55,7 @@ NPAgrReferential.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPAgrReferential.Presence'
+  N.levels : 2
   N.entries : 138
   N.languages : 92
   N.missing : 882
@@ -67,6 +71,7 @@ NPAgrRole.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPAgrRole.Presence'
+  N.levels : 2
   N.entries : 138
   N.languages : 92
   N.missing : 882
@@ -82,6 +87,7 @@ NPAlienabilityConstraint.alienable.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPAlienabilityConstraint.alienable.Presence'
+  N.levels : 2
   N.entries : 653
   N.languages : 307
   N.missing : 367
@@ -97,6 +103,7 @@ NPAlienabilityConstraint.fluid.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPAlienabilityConstraint.fluid.Presence'
+  N.levels : 2
   N.entries : 653
   N.languages : 307
   N.missing : 367
@@ -112,6 +119,7 @@ NPAlienabilityConstraint.inalienable.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPAlienabilityConstraint.inalienable.Presence'
+  N.levels : 2
   N.entries : 653
   N.languages : 307
   N.missing : 367
@@ -127,6 +135,7 @@ NPBroadLocus.D.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPBroadLocus.D.Presence'
+  N.levels : 2
   N.entries : 429
   N.languages : 225
   N.missing : 591
@@ -142,6 +151,7 @@ NPBroadLocus.D_on_H.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPBroadLocus.D_on_H.Presence'
+  N.levels : 2
   N.entries : 429
   N.languages : 225
   N.missing : 591
@@ -157,6 +167,7 @@ NPBroadLocus.F.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPBroadLocus.F.Presence'
+  N.levels : 2
   N.entries : 429
   N.languages : 225
   N.missing : 591
@@ -172,6 +183,7 @@ NPBroadLocus.H.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPBroadLocus.H.Presence'
+  N.levels : 2
   N.entries : 429
   N.languages : 225
   N.missing : 591
@@ -187,6 +199,7 @@ NPDepSemClassConstraint.animate.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepSemClassConstraint.animate.Presence'
+  N.levels : 2
   N.entries : 207
   N.languages : 113
   N.missing : 813
@@ -202,6 +215,7 @@ NPDepSemClassConstraint.high_indexability.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepSemClassConstraint.high_indexability.Presence'
+  N.levels : 2
   N.entries : 207
   N.languages : 113
   N.missing : 813
@@ -217,6 +231,7 @@ NPDepSemClassConstraint.human.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepSemClassConstraint.human.Presence'
+  N.levels : 2
   N.entries : 207
   N.languages : 113
   N.missing : 813
@@ -232,6 +247,7 @@ NPDepSemClassConstraint.inanimate.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepSemClassConstraint.inanimate.Presence'
+  N.levels : 2
   N.entries : 207
   N.languages : 113
   N.missing : 813
@@ -247,6 +263,7 @@ NPDepSemClassConstraint.low_indexability.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepSemClassConstraint.low_indexability.Presence'
+  N.levels : 2
   N.entries : 207
   N.languages : 113
   N.missing : 813
@@ -262,6 +279,7 @@ NPDepSemClassConstraint.meronyms.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepSemClassConstraint.meronyms.Presence'
+  N.levels : 2
   N.entries : 207
   N.languages : 113
   N.missing : 813
@@ -277,6 +295,7 @@ NPDepSemClassConstraint.non_specific.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepSemClassConstraint.non_specific.Presence'
+  N.levels : 2
   N.entries : 207
   N.languages : 113
   N.missing : 813
@@ -292,6 +311,7 @@ NPDepSemClassConstraint.specific.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepSemClassConstraint.specific.Presence'
+  N.levels : 2
   N.entries : 207
   N.languages : 113
   N.missing : 813
@@ -307,6 +327,7 @@ NPDepCatConstraint.1_2Pro_or_N.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.1_2Pro_or_N.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -322,6 +343,7 @@ NPDepCatConstraint.2_or_3Pro.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.2_or_3Pro.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -337,6 +359,7 @@ NPDepCatConstraint.3Pro.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.3Pro.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -352,6 +375,7 @@ NPDepCatConstraint.3sgPro.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.3sgPro.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -367,6 +391,7 @@ NPDepCatConstraint.Adj.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.Adj.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -382,6 +407,7 @@ NPDepCatConstraint.Adp.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.Adp.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -397,6 +423,7 @@ NPDepCatConstraint.AdvP.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.AdvP.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -412,6 +439,7 @@ NPDepCatConstraint.Art.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.Art.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -427,6 +455,7 @@ NPDepCatConstraint.DEM.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.DEM.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -442,6 +471,7 @@ NPDepCatConstraint.N.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.N.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -457,6 +487,7 @@ NPDepCatConstraint.N_or_Pro.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.N_or_Pro.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -472,6 +503,7 @@ NPDepCatConstraint.N_proper.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.N_proper.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -487,6 +519,7 @@ NPDepCatConstraint.nonSAP.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.nonSAP.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -502,6 +535,7 @@ NPDepCatConstraint.NP.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.NP.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -517,6 +551,7 @@ NPDepCatConstraint.Num.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.Num.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -532,6 +567,7 @@ NPDepCatConstraint.Num_above_20.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.Num_above_20.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -547,6 +583,7 @@ NPDepCatConstraint.Nv.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.Nv.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -562,6 +599,7 @@ NPDepCatConstraint.Ord.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.Ord.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -577,6 +615,7 @@ NPDepCatConstraint.Ord1.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.Ord1.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -592,6 +631,7 @@ NPDepCatConstraint.Pro.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.Pro.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -607,6 +647,7 @@ NPDepCatConstraint.PTCP.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.PTCP.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -622,6 +663,7 @@ NPDepCatConstraint.Quant.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.Quant.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -637,6 +679,7 @@ NPDepCatConstraint.S.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.S.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -652,6 +695,7 @@ NPDepCatConstraint.SAP.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.SAP.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -667,6 +711,7 @@ NPDepCatConstraint.V.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDepCatConstraint.V.Presence'
+  N.levels : 2
   N.entries : 879
   N.languages : 429
   N.missing : 141
@@ -682,6 +727,7 @@ NPMarkerFusion.concatenative.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.concatenative.Presence'
+  N.levels : 2
   N.entries : 268
   N.languages : 144
   N.missing : 752
@@ -697,6 +743,7 @@ NPMarkerFusion.isolating.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.isolating.Presence'
+  N.levels : 2
   N.entries : 268
   N.languages : 144
   N.missing : 752
@@ -712,6 +759,7 @@ NPMarkerFusion.reduplicative.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.reduplicative.Presence'
+  N.levels : 1
   N.entries : 268
   N.languages : 144
   N.missing : 752
@@ -727,6 +775,7 @@ NPMarkerFusion.replacive.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.replacive.Presence'
+  N.levels : 1
   N.entries : 268
   N.languages : 144
   N.missing : 752
@@ -742,6 +791,7 @@ NPMarkerFusion.stem.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.stem.Presence'
+  N.levels : 2
   N.entries : 268
   N.languages : 144
   N.missing : 752
@@ -757,6 +807,7 @@ NPMarkerFusion.tonal.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.tonal.Presence'
+  N.levels : 2
   N.entries : 268
   N.languages : 144
   N.missing : 752
@@ -772,6 +823,7 @@ NPMarkerFusion.ablaut.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.ablaut.Presence'
+  N.levels : 1
   N.entries : 270
   N.languages : 144
   N.missing : 750
@@ -787,6 +839,7 @@ NPMarkerFusion.ablaut_or_suppletive.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.ablaut_or_suppletive.Presence'
+  N.levels : 1
   N.entries : 270
   N.languages : 144
   N.missing : 750
@@ -802,6 +855,7 @@ NPMarkerFusion.ablaut_or_tonal.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.ablaut_or_tonal.Presence'
+  N.levels : 1
   N.entries : 270
   N.languages : 144
   N.missing : 750
@@ -817,6 +871,7 @@ NPMarkerFusion.concatenative_then_isolating.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.concatenative_then_isolating.Presence'
+  N.levels : 1
   N.entries : 270
   N.languages : 144
   N.missing : 750
@@ -832,6 +887,7 @@ NPMarkerFusion.concat_ablaut.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.concat_ablaut.Presence'
+  N.levels : 1
   N.entries : 270
   N.languages : 144
   N.missing : 750
@@ -847,6 +903,7 @@ NPMarkerFusion.concat_redupl.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.concat_redupl.Presence'
+  N.levels : 1
   N.entries : 270
   N.languages : 144
   N.missing : 750
@@ -862,6 +919,7 @@ NPMarkerFusion.concatenative_or_suppletive.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.concatenative_or_suppletive.Presence'
+  N.levels : 2
   N.entries : 270
   N.languages : 144
   N.missing : 750
@@ -877,6 +935,7 @@ NPMarkerFusion.concatenative_or_tonal.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.concatenative_or_tonal.Presence'
+  N.levels : 1
   N.entries : 270
   N.languages : 144
   N.missing : 750
@@ -892,6 +951,7 @@ NPMarkerFusion.distributed.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.distributed.Presence'
+  N.levels : 1
   N.entries : 270
   N.languages : 144
   N.missing : 750
@@ -907,6 +967,7 @@ NPMarkerFusion.isolating_then_concatenative.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.isolating_then_concatenative.Presence'
+  N.levels : 1
   N.entries : 270
   N.languages : 144
   N.missing : 750
@@ -922,6 +983,7 @@ NPMarkerFusion.lenition.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.lenition.Presence'
+  N.levels : 2
   N.entries : 270
   N.languages : 144
   N.missing : 750
@@ -937,6 +999,7 @@ NPMarkerFusion.tonal_or_ablaut_then_isolating.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.tonal_or_ablaut_then_isolating.Presence'
+  N.levels : 1
   N.entries : 270
   N.languages : 144
   N.missing : 750
@@ -952,6 +1015,7 @@ NPMarkerFusion.prosodic_template.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.prosodic_template.Presence'
+  N.levels : 2
   N.entries : 270
   N.languages : 144
   N.missing : 750
@@ -967,6 +1031,7 @@ NPMarkerFusion.reduplicative_or_suppletive.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.reduplicative_or_suppletive.Presence'
+  N.levels : 1
   N.entries : 270
   N.languages : 144
   N.missing : 750
@@ -982,6 +1047,7 @@ NPMarkerFusion.reduplication.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.reduplication.Presence'
+  N.levels : 1
   N.entries : 270
   N.languages : 144
   N.missing : 750
@@ -997,6 +1063,7 @@ NPMarkerFusion.suppletive.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.suppletive.Presence'
+  N.levels : 2
   N.entries : 270
   N.languages : 144
   N.missing : 750
@@ -1012,6 +1079,7 @@ NPMarkerFusion.tonal_or_suppletive.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.tonal_or_suppletive.Presence'
+  N.levels : 1
   N.entries : 270
   N.languages : 144
   N.missing : 750
@@ -1027,6 +1095,7 @@ NPHeadSemConstraint.formal.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.formal.Presence'
+  N.levels : 2
   N.entries : 458
   N.languages : 243
   N.missing : 562
@@ -1042,6 +1111,7 @@ NPHeadSemConstraint.kin.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.kin.Presence'
+  N.levels : 2
   N.entries : 458
   N.languages : 243
   N.missing : 562
@@ -1057,6 +1127,7 @@ NPHeadSemConstraint.kinds.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.kinds.Presence'
+  N.levels : 2
   N.entries : 458
   N.languages : 243
   N.missing : 562
@@ -1072,6 +1143,7 @@ NPHeadSemConstraint.names.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.names.Presence'
+  N.levels : 2
   N.entries : 458
   N.languages : 243
   N.missing : 562
@@ -1087,6 +1159,7 @@ NPHeadSemConstraint.parts.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.parts.Presence'
+  N.levels : 2
   N.entries : 458
   N.languages : 243
   N.missing : 562
@@ -1102,6 +1175,7 @@ NPHeadSemConstraint.pragmatic.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.pragmatic.Presence'
+  N.levels : 2
   N.entries : 458
   N.languages : 243
   N.missing : 562
@@ -1117,6 +1191,7 @@ NPHeadSemConstraint.referentiality.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.referentiality.Presence'
+  N.levels : 2
   N.entries : 458
   N.languages : 243
   N.missing : 562
@@ -1132,6 +1207,7 @@ NPHeadSemConstraint.alienable.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.alienable.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1147,6 +1223,7 @@ NPHeadSemConstraint.animals.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.animals.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1162,6 +1239,7 @@ NPHeadSemConstraint.body_parts.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.body_parts.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1177,6 +1255,7 @@ NPHeadSemConstraint.classifiers.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.classifiers.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1192,6 +1271,7 @@ NPHeadSemConstraint.clothing_terms.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.clothing_terms.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1207,6 +1287,7 @@ NPHeadSemConstraint.drinkable.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.drinkable.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1222,6 +1303,7 @@ NPHeadSemConstraint.edible.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.edible.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1237,6 +1319,7 @@ NPHeadSemConstraint.high_indexability.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.high_indexability.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1252,6 +1335,7 @@ NPHeadSemConstraint.human.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.human.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1267,6 +1351,7 @@ NPHeadSemConstraint.inalienable.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.inalienable.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1282,6 +1367,7 @@ NPHeadSemConstraint.kin_terms.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.kin_terms.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1297,6 +1383,7 @@ NPHeadSemConstraint.meronyms.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.meronyms.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1312,6 +1399,7 @@ NPHeadSemConstraint.non_human.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.non_human.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1327,6 +1415,7 @@ NPHeadSemConstraint.non_specific.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.non_specific.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1342,6 +1431,7 @@ NPHeadSemConstraint.origin.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.origin.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1357,6 +1447,7 @@ NPHeadSemConstraint.owner.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.owner.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1372,6 +1463,7 @@ NPHeadSemConstraint.parents_siblings.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.parents_siblings.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1387,6 +1479,7 @@ NPHeadSemConstraint.plant_parts.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.plant_parts.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1402,6 +1495,7 @@ NPHeadSemConstraint.plants.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.plants.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1417,6 +1511,7 @@ NPHeadSemConstraint.property.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.property.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1432,6 +1527,7 @@ NPHeadSemConstraint.quantificational.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.quantificational.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1447,6 +1543,7 @@ NPHeadSemConstraint.rocks.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.rocks.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1462,6 +1559,7 @@ NPHeadSemConstraint.semantic.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.semantic.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1477,6 +1575,7 @@ NPHeadSemConstraint.singular.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.singular.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1492,6 +1591,7 @@ NPHeadSemConstraint.specific.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.specific.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1507,6 +1607,7 @@ NPHeadSemConstraint.spouse.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.spouse.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1522,6 +1623,7 @@ NPHeadSemConstraint.subsets.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.subsets.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1537,6 +1639,7 @@ NPHeadSemConstraint.topological.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.topological.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1552,6 +1655,7 @@ NPHeadSemConstraint.tracks.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.tracks.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1567,6 +1671,7 @@ NPHeadSemConstraint.transportation_means.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.transportation_means.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1582,6 +1687,7 @@ NPHeadSemConstraint.unspecified_inanimate.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.unspecified_inanimate.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1597,6 +1703,7 @@ NPHeadSemConstraint.village_group.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.village_group.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1612,6 +1719,7 @@ NPHeadSemConstraint.volitional.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.volitional.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1627,6 +1735,7 @@ NPHeadSemConstraint.weapon.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPHeadSemConstraint.weapon.Presence'
+  N.levels : 2
   N.entries : 460
   N.languages : 243
   N.missing : 560
@@ -1642,6 +1751,7 @@ NPDetailedLocus.D.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDetailedLocus.D.Presence'
+  N.levels : 2
   N.entries : 429
   N.languages : 225
   N.missing : 591
@@ -1657,6 +1767,7 @@ NPDetailedLocus.d_on_h.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDetailedLocus.d_on_h.Presence'
+  N.levels : 1
   N.entries : 429
   N.languages : 225
   N.missing : 591
@@ -1672,6 +1783,7 @@ NPDetailedLocus.D_on_H.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDetailedLocus.D_on_H.Presence'
+  N.levels : 2
   N.entries : 429
   N.languages : 225
   N.missing : 591
@@ -1687,6 +1799,7 @@ NPDetailedLocus.F.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDetailedLocus.F.Presence'
+  N.levels : 2
   N.entries : 429
   N.languages : 225
   N.missing : 591
@@ -1702,6 +1815,7 @@ NPDetailedLocus.H.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDetailedLocus.H.Presence'
+  N.levels : 2
   N.entries : 429
   N.languages : 225
   N.missing : 591
@@ -1717,6 +1831,7 @@ NPDetailedLocus.P.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPDetailedLocus.P.Presence'
+  N.levels : 1
   N.entries : 429
   N.languages : 225
   N.missing : 591
@@ -1732,6 +1847,7 @@ NPMarkersSource.agr_target.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkersSource.agr_target'
+  N.levels : 2
   N.entries : 200
   N.languages : 109
   N.missing : 820
@@ -1748,6 +1864,7 @@ NPMarkersSource.agree.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkersSource.agree'
+  N.levels : 2
   N.entries : 200
   N.languages : 109
   N.missing : 820
@@ -1764,6 +1881,7 @@ NPMarkersSource.assign.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkersSource.assign'
+  N.levels : 2
   N.entries : 200
   N.languages : 109
   N.missing : 820
@@ -1780,6 +1898,7 @@ NPMarkersSource.both_assign_and_agree.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkersSource.both_assign_and_agree'
+  N.levels : 2
   N.entries : 200
   N.languages : 109
   N.missing : 820
@@ -1796,6 +1915,7 @@ NPMarkersSource.case_assigned_gender_agrees.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkersSource.case_assigned_gender_agrees'
+  N.levels : 2
   N.entries : 200
   N.languages : 109
   N.missing : 820
@@ -1812,6 +1932,7 @@ NPMarkersSource.free.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkersSource.free'
+  N.levels : 2
   N.entries : 200
   N.languages : 109
   N.missing : 820
@@ -1828,6 +1949,7 @@ NPMarkerType.formative.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerType.Presence.formative'
+  N.levels : 2
   N.entries : 339
   N.languages : 192
   N.missing : 681
@@ -1843,6 +1965,7 @@ NPMarkerType.word.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerType.Presence.formative'
+  N.levels : 2
   N.entries : 339
   N.languages : 192
   N.missing : 681
@@ -1858,6 +1981,7 @@ NPMarkerFusion.nonlinear.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NPMarkerFusion.nonlinear.Presence'
+  N.levels : 2
   N.entries : 268
   N.languages : 144
   N.missing : 752

--- a/metadata/Numeral_classifiers.yaml
+++ b/metadata/Numeral_classifiers.yaml
@@ -7,6 +7,7 @@ NumClass.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'NumClass'
+  N.levels : 22
   N.entries : 238
   N.languages : 237
   N.missing : 17
@@ -21,6 +22,7 @@ NumClass.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'NumClass'
+  N.levels : 2
   N.entries : 250
   N.languages : 249
   N.missing : 5

--- a/metadata/Register.yaml
+++ b/metadata/Register.yaml
@@ -7,6 +7,7 @@ LID:
   VariableType : 'register'
   DataType : 'count'
   VariantOf : 'LID'
+  N.levels : 2950
   N.entries : 2950
   N.languages : 2950
   N.missing : 0
@@ -152,6 +153,7 @@ Longitude:
   VariableType : 'register'
   DataType : 'ratio'
   VariantOf : 'Longitude'
+  N.levels : 1604
   N.entries : 2949
   N.languages : 2949
   N.missing : 1
@@ -169,6 +171,7 @@ Latitude:
   VariableType : 'register'
   DataType : 'ratio'
   VariantOf : 'Latitude'
+  N.levels : 1090
   N.entries : 2949
   N.languages : 2949
   N.missing : 1

--- a/metadata/Synthesis.yaml
+++ b/metadata/Synthesis.yaml
@@ -7,6 +7,7 @@ VInlfCatSurveyComplete:
   VariableType : 'quality'
   DataType : 'logical'
   VariantOf : 'VInlfCatSurveyComplete'
+  N.levels : 2
   N.entries : 184
   N.languages : 184
   N.missing : 190
@@ -21,6 +22,7 @@ VBipartiteStem.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VBipartiteStem.Presence'
+  N.levels : 2
   N.entries : 180
   N.languages : 180
   N.missing : 194
@@ -4979,6 +4981,7 @@ VInflCatAndAgrMax.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'VInflCatAndAgrMax.n'
+  N.levels : 15
   N.entries : 331
   N.languages : 331
   N.missing : 43
@@ -4994,6 +4997,7 @@ VInflCatMax.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'VInflCatMax.n'
+  N.levels : 11
   N.entries : 251
   N.languages : 251
   N.missing : 123
@@ -5039,6 +5043,7 @@ VInflCatAndAgrFmtvMax.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'VInflCatandAgrFmtvMax.n'
+  N.levels : 20
   N.entries : 320
   N.languages : 320
   N.missing : 54
@@ -5052,6 +5057,7 @@ VInflCatFmtvMax.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'VInflCatFmtvMax.n'
+  N.levels : 17
   N.entries : 204
   N.languages : 204
   N.missing : 170
@@ -5079,6 +5085,7 @@ VAnyIncorporation.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VAnyIncorporation.Presence'
+  N.levels : 2
   N.entries : 374
   N.languages : 374
   N.missing : 0
@@ -5108,6 +5115,7 @@ VNounIncorporation.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VNounIncorporation.Presence'
+  N.levels : 2
   N.entries : 80
   N.languages : 80
   N.missing : 294
@@ -5121,6 +5129,7 @@ VPhonCoherence.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VPhonCoherence.Presence'
+  N.levels : 2
   N.entries : 91
   N.languages : 91
   N.missing : 283
@@ -5134,6 +5143,7 @@ VAgrAllPre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VAgrAllPre.Presence'
+  N.levels : 2
   N.entries : 277
   N.languages : 277
   N.missing : 97
@@ -5147,6 +5157,7 @@ VAgrAnyPre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VAgrAnyPre.Presence'
+  N.levels : 2
   N.entries : 277
   N.languages : 277
   N.missing : 97
@@ -5160,6 +5171,7 @@ VProsCoherence.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VProsCoherence.Presence'
+  N.levels : 2
   N.entries : 129
   N.languages : 129
   N.missing : 245
@@ -5330,6 +5342,7 @@ VInflMax.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'VInflMax.n'
+  N.levels : 30
   N.entries : 320
   N.languages : 320
   N.missing : 54
@@ -5343,6 +5356,7 @@ VSynCoherence.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VSynCoherence.Presence'
+  N.levels : 2
   N.entries : 120
   N.languages : 120
   N.missing : 254
@@ -5371,6 +5385,7 @@ VIncorporationVorN.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VIncorporationVorN.Presence'
+  N.levels : 2
   N.entries : 80
   N.languages : 80
   N.missing : 294
@@ -5384,6 +5399,7 @@ VIncorporationV.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VIncorporationV.Presence'
+  N.levels : 2
   N.entries : 80
   N.languages : 80
   N.missing : 294

--- a/metadata/VAgr_multiexponence.yaml
+++ b/metadata/VAgr_multiexponence.yaml
@@ -7,6 +7,7 @@ VAgrA.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VAgrA.Pre.Presence'
+  N.levels : 2
   N.entries : 250
   N.languages : 250
   N.missing : 23
@@ -23,6 +24,7 @@ VAgrP.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VAgrP.Pre.Presence'
+  N.levels : 2
   N.entries : 194
   N.languages : 194
   N.missing : 79
@@ -40,6 +42,7 @@ VAgrPOSS.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VAgrPOSS.Pre.Presence'
+  N.levels : 1
   N.entries : 3
   N.languages : 3
   N.missing : 270

--- a/metadata/VAgr_postposed.yaml
+++ b/metadata/VAgr_postposed.yaml
@@ -7,6 +7,7 @@ VAgrA.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VAgrA.Post.Presence'
+  N.levels : 2
   N.entries : 252
   N.languages : 250
   N.missing : 27
@@ -23,6 +24,7 @@ VAgrP.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VAgrP.Post.Presence'
+  N.levels : 2
   N.entries : 196
   N.languages : 190
   N.missing : 83
@@ -40,6 +42,7 @@ VAgrPOSS.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VAgrPOSS.Post.Presence'
+  N.levels : 2
   N.entries : 3
   N.languages : 3
   N.missing : 276

--- a/metadata/VAgr_preposed.yaml
+++ b/metadata/VAgr_preposed.yaml
@@ -7,6 +7,7 @@ VAgrA.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VAgrA.Pre.Presence'
+  N.levels : 2
   N.entries : 252
   N.languages : 250
   N.missing : 30
@@ -23,6 +24,7 @@ VAgrP.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VAgrP.Pre.Presence'
+  N.levels : 2
   N.entries : 201
   N.languages : 194
   N.missing : 81
@@ -40,6 +42,7 @@ VAgrPOSS.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VAgrPOSS.Pre.Presence'
+  N.levels : 2
   N.entries : 3
   N.languages : 3
   N.missing : 279

--- a/metadata/VAgreement.yaml
+++ b/metadata/VAgreement.yaml
@@ -7,6 +7,7 @@ VAgrA.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VAgrA.Presence'
+  N.levels : 2
   N.entries : 277
   N.languages : 277
   N.missing : 18
@@ -22,6 +23,7 @@ VAgrP.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VAgrP.Presence'
+  N.levels : 2
   N.entries : 246
   N.languages : 246
   N.missing : 49
@@ -38,6 +40,7 @@ VAgrPOSS.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VAgrPOSS.Presence'
+  N.levels : 2
   N.entries : 116
   N.languages : 116
   N.missing : 179

--- a/metadata/VInfl_cat_multiexponence.yaml
+++ b/metadata/VInfl_cat_multiexponence.yaml
@@ -8,6 +8,7 @@ VInflAktionsart.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflAktionsart.Pre.Presence'
+  N.levels : 1
   N.entries : 32
   N.languages : 32
   N.missing : 201
@@ -25,6 +26,7 @@ VInflApplicative.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflApplicative.Pre.Presence'
+  N.levels : 1
   N.entries : 22
   N.languages : 22
   N.missing : 211
@@ -42,6 +44,7 @@ VInflAspect.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflAspect.Pre.Presence'
+  N.levels : 2
   N.entries : 94
   N.languages : 94
   N.missing : 139
@@ -59,6 +62,7 @@ VInflCausative.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflCausative.Pre.Presence'
+  N.levels : 1
   N.entries : 42
   N.languages : 42
   N.missing : 191
@@ -76,6 +80,7 @@ VInflClassifier.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflClassifier.Pre.Presence'
+  N.levels : 1
   N.entries : 2
   N.languages : 2
   N.missing : 231
@@ -93,6 +98,7 @@ VInflConnective.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflConnective.Pre.Presence'
+  N.levels : 1
   N.entries : 10
   N.languages : 10
   N.missing : 223
@@ -110,6 +116,7 @@ VInflConstruct.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflConstruct.Pre.Presence'
+  N.levels : 1
   N.entries : 2
   N.languages : 2
   N.missing : 231
@@ -127,6 +134,7 @@ VInflControl.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflControl.Pre.Presence'
+  N.levels : 1
   N.entries : 2
   N.languages : 2
   N.missing : 231
@@ -144,6 +152,7 @@ VInflDeixis.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflDeixis.Pre.Presence'
+  N.levels : 1
   N.entries : 35
   N.languages : 35
   N.missing : 198
@@ -161,6 +170,7 @@ VInflVoice.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflVoice.Pre.Presence'
+  N.levels : 1
   N.entries : 58
   N.languages : 58
   N.missing : 175
@@ -178,6 +188,7 @@ VInflFocus.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflFocus.Pre.Presence'
+  N.levels : 1
   N.entries : 7
   N.languages : 7
   N.missing : 226
@@ -195,6 +206,7 @@ VInflPosterior.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPosterior.Pre.Presence'
+  N.levels : 1
   N.entries : 5
   N.languages : 5
   N.missing : 228
@@ -212,6 +224,7 @@ VInflGender.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflGender.Pre.Presence'
+  N.levels : 1
   N.entries : 4
   N.languages : 4
   N.missing : 229
@@ -229,6 +242,7 @@ VInflIllocution.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflIllocution.Pre.Presence'
+  N.levels : 1
   N.entries : 20
   N.languages : 20
   N.missing : 213
@@ -246,6 +260,7 @@ VInflMA.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMA.Pre.Presence'
+  N.levels : 1
   N.entries : 3
   N.languages : 3
   N.missing : 230
@@ -263,6 +278,7 @@ VInflMN.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMN.Pre.Presence'
+  N.levels : 1
   N.entries : 2
   N.languages : 2
   N.missing : 231
@@ -280,6 +296,7 @@ VInflModality.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflModality.Pre.Presence'
+  N.levels : 1
   N.entries : 10
   N.languages : 10
   N.missing : 223
@@ -297,6 +314,7 @@ VInflMood.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMood.Pre.Presence'
+  N.levels : 1
   N.entries : 53
   N.languages : 53
   N.missing : 180
@@ -314,6 +332,7 @@ VInflMotion.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMotion.Pre.Presence'
+  N.levels : 1
   N.entries : 7
   N.languages : 7
   N.missing : 226
@@ -331,6 +350,7 @@ VInflMSE.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMSE.Pre.Presence'
+  N.levels : 1
   N.entries : 4
   N.languages : 4
   N.missing : 229
@@ -348,6 +368,7 @@ VInflNominalizer.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflNominalizer.Pre.Presence'
+  N.levels : 1
   N.entries : 3
   N.languages : 3
   N.missing : 230
@@ -365,6 +386,7 @@ VInflNumber.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflNumber.Pre.Presence'
+  N.levels : 1
   N.entries : 49
   N.languages : 49
   N.missing : 184
@@ -382,6 +404,7 @@ VInflPerson.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPerson.Pre.Presence'
+  N.levels : 1
   N.entries : 6
   N.languages : 6
   N.missing : 227
@@ -399,6 +422,7 @@ VInflPolarity.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPolarity.Pre.Presence'
+  N.levels : 2
   N.entries : 90
   N.languages : 90
   N.missing : 143
@@ -416,6 +440,7 @@ VInflPotentialis.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPotentialis.Pre.Presence'
+  N.levels : 1
   N.entries : 1
   N.languages : 1
   N.missing : 232
@@ -433,6 +458,7 @@ VInflQuantificational.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflQuantificational.Pre.Presence'
+  N.levels : 2
   N.entries : 48
   N.languages : 48
   N.missing : 185
@@ -450,6 +476,7 @@ VInflReflexive_and_Reciprocal.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflReflexive_and_Reciprocal.Pre.Presence'
+  N.levels : 1
   N.entries : 35
   N.languages : 35
   N.missing : 198
@@ -468,6 +495,7 @@ VInflRECIP.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflRECIP.Pre.Presence'
+  N.levels : 1
   N.entries : 10
   N.languages : 10
   N.missing : 223
@@ -485,6 +513,7 @@ VInflReferential.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflReferential.Pre.Presence'
+  N.levels : 1
   N.entries : 7
   N.languages : 7
   N.missing : 226
@@ -502,6 +531,7 @@ VInflReflexive.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflReflexive.Pre.Presence'
+  N.levels : 1
   N.entries : 14
   N.languages : 14
   N.missing : 219
@@ -519,6 +549,7 @@ VInflRepetition.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflRepetition.Pre.Presence'
+  N.levels : 1
   N.entries : 4
   N.languages : 4
   N.missing : 229
@@ -536,6 +567,7 @@ VInflReversative.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflReversative.Pre.Presence'
+  N.levels : 1
   N.entries : 1
   N.languages : 1
   N.missing : 232
@@ -553,6 +585,7 @@ VInflSemistem.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflSemistem.Pre.Presence'
+  N.levels : 1
   N.entries : 10
   N.languages : 10
   N.missing : 223
@@ -570,6 +603,7 @@ VInflSpatial.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflSpatial.Pre.Presence'
+  N.levels : 1
   N.entries : 5
   N.languages : 5
   N.missing : 228
@@ -587,6 +621,7 @@ VInflStatus.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflStatus.Pre.Presence'
+  N.levels : 2
   N.entries : 22
   N.languages : 22
   N.missing : 211
@@ -604,6 +639,7 @@ VInflSwitch_reference.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflSwitch_reference.Pre.Presence'
+  N.levels : 1
   N.entries : 5
   N.languages : 5
   N.missing : 228
@@ -621,6 +657,7 @@ VInflTense_and_Evidential.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTense_and_Evidential.Pre.Presence'
+  N.levels : 1
   N.entries : 5
   N.languages : 5
   N.missing : 228
@@ -638,6 +675,7 @@ VInflTA.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTA.Pre.Presence'
+  N.levels : 1
   N.entries : 24
   N.languages : 24
   N.missing : 209
@@ -655,6 +693,7 @@ VInflTAM.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTAM.Pre.Presence'
+  N.levels : 2
   N.entries : 86
   N.languages : 86
   N.missing : 147
@@ -672,6 +711,7 @@ VInflTense.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTense.Pre.Presence'
+  N.levels : 1
   N.entries : 77
   N.languages : 77
   N.missing : 156
@@ -689,6 +729,7 @@ VInflTM.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTM.Pre.Presence'
+  N.levels : 1
   N.entries : 23
   N.languages : 23
   N.missing : 210
@@ -706,6 +747,7 @@ VInflValence.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflValence.Pre.Presence'
+  N.levels : 1
   N.entries : 7
   N.languages : 7
   N.missing : 226
@@ -723,6 +765,7 @@ VInflVersion.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflVersion.Pre.Presence'
+  N.levels : 1
   N.entries : 3
   N.languages : 3
   N.missing : 230

--- a/metadata/VInfl_cat_postposed.yaml
+++ b/metadata/VInfl_cat_postposed.yaml
@@ -8,6 +8,7 @@ VInflAktionsart.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflAktionsart.Post.Presence'
+  N.levels : 2
   N.entries : 30
   N.languages : 29
   N.missing : 227
@@ -25,6 +26,7 @@ VInflApplicative.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflApplicative.Post.Presence'
+  N.levels : 2
   N.entries : 23
   N.languages : 22
   N.missing : 234
@@ -42,6 +44,7 @@ VInflAspect.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflAspect.Post.Presence'
+  N.levels : 2
   N.entries : 92
   N.languages : 90
   N.missing : 165
@@ -59,6 +62,7 @@ VInflCausative.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflCausative.Post.Presence'
+  N.levels : 2
   N.entries : 41
   N.languages : 40
   N.missing : 216
@@ -76,6 +80,7 @@ VInflClassifier.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflClassifier.Post.Presence'
+  N.levels : 1
   N.entries : 2
   N.languages : 2
   N.missing : 255
@@ -93,6 +98,7 @@ VInflConnective.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflConnective.Post.Presence'
+  N.levels : 2
   N.entries : 10
   N.languages : 10
   N.missing : 247
@@ -110,6 +116,7 @@ VInflConstruct.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflConstruct.Post.Presence'
+  N.levels : 2
   N.entries : 2
   N.languages : 2
   N.missing : 255
@@ -127,6 +134,7 @@ VInflControl.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflControl.Post.Presence'
+  N.levels : 1
   N.entries : 2
   N.languages : 2
   N.missing : 255
@@ -144,6 +152,7 @@ VInflDeixis.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflDeixis.Post.Presence'
+  N.levels : 2
   N.entries : 35
   N.languages : 35
   N.missing : 222
@@ -161,6 +170,7 @@ VInflVoice.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflVoice.Post.Presence'
+  N.levels : 2
   N.entries : 58
   N.languages : 57
   N.missing : 199
@@ -178,6 +188,7 @@ VInflFocus.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflFocus.Post.Presence'
+  N.levels : 2
   N.entries : 8
   N.languages : 7
   N.missing : 249
@@ -195,6 +206,7 @@ VInflPosterior.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPosterior.Post.Presence'
+  N.levels : 2
   N.entries : 5
   N.languages : 5
   N.missing : 252
@@ -212,6 +224,7 @@ VInflGender.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflGender.Post.Presence'
+  N.levels : 2
   N.entries : 4
   N.languages : 4
   N.missing : 253
@@ -229,6 +242,7 @@ VInflIllocution.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflIllocution.Post.Presence'
+  N.levels : 2
   N.entries : 21
   N.languages : 20
   N.missing : 236
@@ -246,6 +260,7 @@ VInflMA.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMA.Post.Presence'
+  N.levels : 1
   N.entries : 2
   N.languages : 2
   N.missing : 255
@@ -263,6 +278,7 @@ VInflMN.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMN.Post.Presence'
+  N.levels : 2
   N.entries : 2
   N.languages : 2
   N.missing : 255
@@ -280,6 +296,7 @@ VInflModality.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflModality.Post.Presence'
+  N.levels : 2
   N.entries : 10
   N.languages : 10
   N.missing : 247
@@ -297,6 +314,7 @@ VInflMood.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMood.Post.Presence'
+  N.levels : 2
   N.entries : 53
   N.languages : 53
   N.missing : 204
@@ -314,6 +332,7 @@ VInflMotion.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMotion.Post.Presence'
+  N.levels : 1
   N.entries : 7
   N.languages : 7
   N.missing : 250
@@ -331,6 +350,7 @@ VInflMSE.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMSE.Post.Presence'
+  N.levels : 2
   N.entries : 4
   N.languages : 4
   N.missing : 253
@@ -348,6 +368,7 @@ VInflNominalizer.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflNominalizer.Post.Presence'
+  N.levels : 1
   N.entries : 3
   N.languages : 3
   N.missing : 254
@@ -365,6 +386,7 @@ VInflNumber.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflNumber.Post.Presence'
+  N.levels : 2
   N.entries : 50
   N.languages : 47
   N.missing : 207
@@ -382,6 +404,7 @@ VInflPerson.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPerson.Post.Presence'
+  N.levels : 2
   N.entries : 6
   N.languages : 6
   N.missing : 251
@@ -399,6 +422,7 @@ VInflPolarity.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPolarity.Post.Presence'
+  N.levels : 2
   N.entries : 89
   N.languages : 89
   N.missing : 168
@@ -416,6 +440,7 @@ VInflPotentialis.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPotentialis.Post.Presence'
+  N.levels : 1
   N.entries : 1
   N.languages : 1
   N.missing : 256
@@ -433,6 +458,7 @@ VInflQuantificational.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflQuantificational.Post.Presence'
+  N.levels : 2
   N.entries : 38
   N.languages : 37
   N.missing : 219
@@ -450,6 +476,7 @@ VInflReflexive_and_Reciprocal.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflReflexive_and_Reciprocal.Post.Presence'
+  N.levels : 2
   N.entries : 35
   N.languages : 35
   N.missing : 222
@@ -467,6 +494,7 @@ VInflRECIP.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflRECIP.Post.Presence'
+  N.levels : 2
   N.entries : 9
   N.languages : 9
   N.missing : 248
@@ -484,6 +512,7 @@ VInflReferential.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflReferential.Post.Presence'
+  N.levels : 2
   N.entries : 7
   N.languages : 7
   N.missing : 250
@@ -501,6 +530,7 @@ VInflReflexive.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflReflexive.Post.Presence'
+  N.levels : 2
   N.entries : 13
   N.languages : 13
   N.missing : 244
@@ -518,6 +548,7 @@ VInflRepetition.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflRepetition.Post.Presence'
+  N.levels : 2
   N.entries : 3
   N.languages : 3
   N.missing : 254
@@ -535,6 +566,7 @@ VInflReversative.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflReversative.Post.Presence'
+  N.levels : 1
   N.entries : 1
   N.languages : 1
   N.missing : 256
@@ -552,6 +584,7 @@ VInflSemistem.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflSemistem.Post.Presence'
+  N.levels : 1
   N.entries : 10
   N.languages : 10
   N.missing : 247
@@ -569,6 +602,7 @@ VInflSpatial.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflSpatial.Post.Presence'
+  N.levels : 2
   N.entries : 5
   N.languages : 5
   N.missing : 252
@@ -586,6 +620,7 @@ VInflStatus.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflStatus.Post.Presence'
+  N.levels : 2
   N.entries : 22
   N.languages : 21
   N.missing : 235
@@ -603,6 +638,7 @@ VInflSwitch_reference.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflSwitch_reference.Post.Presence'
+  N.levels : 1
   N.entries : 5
   N.languages : 5
   N.missing : 252
@@ -620,6 +656,7 @@ VInflTense_and_Evidential.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTense_and_Evidential.Post.Presence'
+  N.levels : 1
   N.entries : 5
   N.languages : 5
   N.missing : 252
@@ -637,6 +674,7 @@ VInflTA.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTA.Post.Presence'
+  N.levels : 2
   N.entries : 25
   N.languages : 23
   N.missing : 232
@@ -654,6 +692,7 @@ VInflTAM.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTAM.Post.Presence'
+  N.levels : 2
   N.entries : 91
   N.languages : 85
   N.missing : 166
@@ -671,6 +710,7 @@ VInflTense.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTense.Post.Presence'
+  N.levels : 2
   N.entries : 80
   N.languages : 77
   N.missing : 177
@@ -688,6 +728,7 @@ VInflTM.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTM.Post.Presence'
+  N.levels : 2
   N.entries : 23
   N.languages : 23
   N.missing : 234
@@ -705,6 +746,7 @@ VInflValence.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflValence.Post.Presence'
+  N.levels : 2
   N.entries : 6
   N.languages : 6
   N.missing : 251
@@ -722,6 +764,7 @@ VInflVersion.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflVersion.Post.Presence'
+  N.levels : 1
   N.entries : 3
   N.languages : 3
   N.missing : 254

--- a/metadata/VInfl_cat_preposed.yaml
+++ b/metadata/VInfl_cat_preposed.yaml
@@ -8,6 +8,7 @@ VInflAktionsart.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflAktionsart.Pre.Presence'
+  N.levels : 2
   N.entries : 33
   N.languages : 32
   N.missing : 226
@@ -25,6 +26,7 @@ VInflApplicative.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflApplicative.Pre.Presence'
+  N.levels : 2
   N.entries : 23
   N.languages : 22
   N.missing : 236
@@ -42,6 +44,7 @@ VInflAspect.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflAspect.Pre.Presence'
+  N.levels : 2
   N.entries : 97
   N.languages : 94
   N.missing : 162
@@ -59,6 +62,7 @@ VInflCausative.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflCausative.Pre.Presence'
+  N.levels : 2
   N.entries : 43
   N.languages : 42
   N.missing : 216
@@ -76,6 +80,7 @@ VInflClassifier.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflClassifier.Pre.Presence'
+  N.levels : 1
   N.entries : 2
   N.languages : 2
   N.missing : 257
@@ -93,6 +98,7 @@ VInflConnective.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflConnective.Pre.Presence'
+  N.levels : 2
   N.entries : 10
   N.languages : 10
   N.missing : 249
@@ -110,6 +116,7 @@ VInflConstruct.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflConstruct.Pre.Presence'
+  N.levels : 2
   N.entries : 2
   N.languages : 2
   N.missing : 257
@@ -127,6 +134,7 @@ VInflControl.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflControl.Pre.Presence'
+  N.levels : 1
   N.entries : 2
   N.languages : 2
   N.missing : 257
@@ -144,6 +152,7 @@ VInflDeixis.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflDeixis.Pre.Presence'
+  N.levels : 2
   N.entries : 35
   N.languages : 35
   N.missing : 224
@@ -161,6 +170,7 @@ VInflVoice.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflVoice.Pre.Presence'
+  N.levels : 2
   N.entries : 59
   N.languages : 58
   N.missing : 200
@@ -178,6 +188,7 @@ VInflFocus.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflFocus.Pre.Presence'
+  N.levels : 2
   N.entries : 8
   N.languages : 7
   N.missing : 251
@@ -195,6 +206,7 @@ VInflPosterior.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPosterior.Pre.Presence'
+  N.levels : 2
   N.entries : 5
   N.languages : 5
   N.missing : 254
@@ -212,6 +224,7 @@ VInflGender.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflGender.Pre.Presence'
+  N.levels : 2
   N.entries : 4
   N.languages : 4
   N.missing : 255
@@ -229,6 +242,7 @@ VInflIllocution.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflIllocution.Pre.Presence'
+  N.levels : 2
   N.entries : 21
   N.languages : 20
   N.missing : 238
@@ -246,6 +260,7 @@ VInflMA.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMA.Pre.Presence'
+  N.levels : 1
   N.entries : 3
   N.languages : 3
   N.missing : 256
@@ -263,6 +278,7 @@ VInflMN.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMN.Pre.Presence'
+  N.levels : 2
   N.entries : 2
   N.languages : 2
   N.missing : 257
@@ -280,6 +296,7 @@ VInflModality.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflModality.Pre.Presence'
+  N.levels : 2
   N.entries : 10
   N.languages : 10
   N.missing : 249
@@ -297,6 +314,7 @@ VInflMood.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMood.Pre.Presence'
+  N.levels : 2
   N.entries : 54
   N.languages : 54
   N.missing : 205
@@ -314,6 +332,7 @@ VInflMotion.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMotion.Pre.Presence'
+  N.levels : 1
   N.entries : 7
   N.languages : 7
   N.missing : 252
@@ -331,6 +350,7 @@ VInflMSE.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMSE.Pre.Presence'
+  N.levels : 2
   N.entries : 4
   N.languages : 4
   N.missing : 255
@@ -348,6 +368,7 @@ VInflNominalizer.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflNominalizer.Pre.Presence'
+  N.levels : 1
   N.entries : 3
   N.languages : 3
   N.missing : 256
@@ -365,6 +386,7 @@ VInflNumber.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflNumber.Pre.Presence'
+  N.levels : 2
   N.entries : 52
   N.languages : 49
   N.missing : 207
@@ -382,6 +404,7 @@ VInflPerson.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPerson.Pre.Presence'
+  N.levels : 2
   N.entries : 6
   N.languages : 6
   N.missing : 253
@@ -399,6 +422,7 @@ VInflPolarity.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPolarity.Pre.Presence'
+  N.levels : 2
   N.entries : 91
   N.languages : 91
   N.missing : 168
@@ -416,6 +440,7 @@ VInflPotentialis.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPotentialis.Pre.Presence'
+  N.levels : 1
   N.entries : 1
   N.languages : 1
   N.missing : 258
@@ -433,6 +458,7 @@ VInflQuantificational.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflQuantificational.Pre.Presence'
+  N.levels : 2
   N.entries : 50
   N.languages : 48
   N.missing : 209
@@ -450,6 +476,7 @@ VInflReflexive_and_Reciprocal.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflReflexive_and_Reciprocal.Pre.Presence'
+  N.levels : 2
   N.entries : 35
   N.languages : 35
   N.missing : 224
@@ -467,6 +494,7 @@ VInflRECIP.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflRECIP.Pre.Presence'
+  N.levels : 2
   N.entries : 10
   N.languages : 10
   N.missing : 249
@@ -484,6 +512,7 @@ VInflReferential.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflReferential.Pre.Presence'
+  N.levels : 2
   N.entries : 7
   N.languages : 7
   N.missing : 252
@@ -501,6 +530,7 @@ VInflReflexive.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflReflexive.Pre.Presence'
+  N.levels : 2
   N.entries : 14
   N.languages : 14
   N.missing : 245
@@ -518,6 +548,7 @@ VInflRepetition.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflRepetition.Pre.Presence'
+  N.levels : 2
   N.entries : 4
   N.languages : 4
   N.missing : 255
@@ -535,6 +566,7 @@ VInflReversative.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflReversative.Pre.Presence'
+  N.levels : 1
   N.entries : 1
   N.languages : 1
   N.missing : 258
@@ -552,6 +584,7 @@ VInflSemistem.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflSemistem.Pre.Presence'
+  N.levels : 1
   N.entries : 10
   N.languages : 10
   N.missing : 249
@@ -569,6 +602,7 @@ VInflSpatial.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflSpatial.Pre.Presence'
+  N.levels : 2
   N.entries : 5
   N.languages : 5
   N.missing : 254
@@ -586,6 +620,7 @@ VInflStatus.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflStatus.Pre.Presence'
+  N.levels : 2
   N.entries : 23
   N.languages : 22
   N.missing : 236
@@ -603,6 +638,7 @@ VInflSwitch_reference.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflSwitch_reference.Pre.Presence'
+  N.levels : 2
   N.entries : 5
   N.languages : 5
   N.missing : 254
@@ -620,6 +656,7 @@ VInflTense_and_Evidential.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTense_and_Evidential.Pre.Presence'
+  N.levels : 2
   N.entries : 5
   N.languages : 5
   N.missing : 254
@@ -637,6 +674,7 @@ VInflTA.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTA.Pre.Presence'
+  N.levels : 2
   N.entries : 27
   N.languages : 24
   N.missing : 232
@@ -654,6 +692,7 @@ VInflTAM.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTAM.Pre.Presence'
+  N.levels : 2
   N.entries : 92
   N.languages : 86
   N.missing : 167
@@ -671,6 +710,7 @@ VInflTense.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTense.Pre.Presence'
+  N.levels : 2
   N.entries : 81
   N.languages : 78
   N.missing : 178
@@ -688,6 +728,7 @@ VInflTM.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTM.Pre.Presence'
+  N.levels : 2
   N.entries : 23
   N.languages : 23
   N.missing : 236
@@ -705,6 +746,7 @@ VInflValence.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflValence.Pre.Presence'
+  N.levels : 2
   N.entries : 7
   N.languages : 7
   N.missing : 252
@@ -722,6 +764,7 @@ VInflVersion.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflVersion.Pre.Presence'
+  N.levels : 1
   N.entries : 3
   N.languages : 3
   N.missing : 256

--- a/metadata/VInfl_categories.yaml
+++ b/metadata/VInfl_categories.yaml
@@ -8,6 +8,7 @@ VInflAktionsart.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflAktionsart.Presence'
+  N.levels : 2
   N.entries : 162
   N.languages : 162
   N.missing : 161
@@ -24,6 +25,7 @@ VInflApplicative.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflApplicative.Presence'
+  N.levels : 2
   N.entries : 145
   N.languages : 145
   N.missing : 178
@@ -40,6 +42,7 @@ VInflAspect.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflAspect.Presence'
+  N.levels : 2
   N.entries : 211
   N.languages : 211
   N.missing : 112
@@ -56,6 +59,7 @@ VInflCausative.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflCausative.Presence'
+  N.levels : 2
   N.entries : 152
   N.languages : 152
   N.missing : 171
@@ -72,6 +76,7 @@ VInflClassifier.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflClassifier.Presence'
+  N.levels : 2
   N.entries : 134
   N.languages : 134
   N.missing : 189
@@ -88,6 +93,7 @@ VInflConnective.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflConnective.Presence'
+  N.levels : 2
   N.entries : 147
   N.languages : 147
   N.missing : 176
@@ -104,6 +110,7 @@ VInflConstruct.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflConstruct.Presence'
+  N.levels : 2
   N.entries : 135
   N.languages : 135
   N.missing : 188
@@ -120,6 +127,7 @@ VInflControl.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflControl.Presence'
+  N.levels : 2
   N.entries : 133
   N.languages : 133
   N.missing : 190
@@ -136,6 +144,7 @@ VInflDeixis.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflDeixis.Presence'
+  N.levels : 2
   N.entries : 152
   N.languages : 152
   N.missing : 171
@@ -152,6 +161,7 @@ VInflVoice.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflVoice.Presence'
+  N.levels : 2
   N.entries : 179
   N.languages : 179
   N.missing : 144
@@ -168,6 +178,7 @@ VInflFocus.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflFocus.Presence'
+  N.levels : 2
   N.entries : 139
   N.languages : 139
   N.missing : 184
@@ -184,6 +195,7 @@ VInflPosterior.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPosterior.Presence'
+  N.levels : 2
   N.entries : 137
   N.languages : 137
   N.missing : 186
@@ -200,6 +212,7 @@ VInflGender.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflGender.Presence'
+  N.levels : 2
   N.entries : 134
   N.languages : 134
   N.missing : 189
@@ -216,6 +229,7 @@ VInflHonorificity.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflHonorificity.Presence'
+  N.levels : 2
   N.entries : 133
   N.languages : 133
   N.missing : 190
@@ -232,6 +246,7 @@ VInflIllocution.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflIllocution.Presence'
+  N.levels : 2
   N.entries : 149
   N.languages : 149
   N.missing : 174
@@ -248,6 +263,7 @@ VInflMA.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMA.Presence'
+  N.levels : 2
   N.entries : 136
   N.languages : 136
   N.missing : 187
@@ -264,6 +280,7 @@ VInflMN.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMN.Presence'
+  N.levels : 2
   N.entries : 134
   N.languages : 134
   N.missing : 189
@@ -280,6 +297,7 @@ VInflModality.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflModality.Presence'
+  N.levels : 2
   N.entries : 142
   N.languages : 142
   N.missing : 181
@@ -296,6 +314,7 @@ VInflMood.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMood.Presence'
+  N.levels : 2
   N.entries : 171
   N.languages : 171
   N.missing : 152
@@ -312,6 +331,7 @@ VInflMotion.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMotion.Presence'
+  N.levels : 2
   N.entries : 136
   N.languages : 136
   N.missing : 187
@@ -328,6 +348,7 @@ VInflMSE.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflMSE.Presence'
+  N.levels : 2
   N.entries : 135
   N.languages : 135
   N.missing : 188
@@ -344,6 +365,7 @@ VInflNominalizer.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflNominalizer.Presence'
+  N.levels : 2
   N.entries : 135
   N.languages : 135
   N.missing : 188
@@ -360,6 +382,7 @@ VInflNumber.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflNumber.Presence'
+  N.levels : 2
   N.entries : 172
   N.languages : 172
   N.missing : 151
@@ -376,6 +399,7 @@ VInflPerson.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPerson.Presence'
+  N.levels : 2
   N.entries : 135
   N.languages : 135
   N.missing : 188
@@ -392,6 +416,7 @@ VInflPolarity.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPolarity.Presence'
+  N.levels : 2
   N.entries : 222
   N.languages : 222
   N.missing : 101
@@ -408,6 +433,7 @@ VInflPotentialis.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPotentialis.Presence'
+  N.levels : 2
   N.entries : 135
   N.languages : 135
   N.missing : 188
@@ -424,6 +450,7 @@ VInflQuantificational.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflQuantificational.Presence'
+  N.levels : 2
   N.entries : 167
   N.languages : 167
   N.missing : 156
@@ -440,6 +467,7 @@ VInflReflexive_and_Reciprocal.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflReflexive_and_Reciprocal.Presence'
+  N.levels : 2
   N.entries : 149
   N.languages : 149
   N.missing : 174
@@ -456,6 +484,7 @@ VInflRECIP.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflRECIP.Presence'
+  N.levels : 2
   N.entries : 141
   N.languages : 141
   N.missing : 182
@@ -472,6 +501,7 @@ VInflReferential.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflReferential.Presence'
+  N.levels : 2
   N.entries : 140
   N.languages : 140
   N.missing : 183
@@ -488,6 +518,7 @@ VInflReflexive.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflReflexive.Presence'
+  N.levels : 2
   N.entries : 140
   N.languages : 140
   N.missing : 183
@@ -504,6 +535,7 @@ VInflRepetition.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflRepetition.Presence'
+  N.levels : 2
   N.entries : 133
   N.languages : 133
   N.missing : 190
@@ -520,6 +552,7 @@ VInflReversative.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflReversative.Presence'
+  N.levels : 2
   N.entries : 132
   N.languages : 132
   N.missing : 191
@@ -536,6 +569,7 @@ VInflSemistem.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflSemistem.Presence'
+  N.levels : 2
   N.entries : 138
   N.languages : 138
   N.missing : 185
@@ -552,6 +586,7 @@ VInflSpatial.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflSpatial.Presence'
+  N.levels : 2
   N.entries : 134
   N.languages : 134
   N.missing : 189
@@ -568,6 +603,7 @@ VInflStatus.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflStatus.Presence'
+  N.levels : 2
   N.entries : 160
   N.languages : 160
   N.missing : 163
@@ -584,6 +620,7 @@ VInflSwitch_reference.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflSwitch_reference.Presence'
+  N.levels : 2
   N.entries : 137
   N.languages : 137
   N.missing : 186
@@ -600,6 +637,7 @@ VInflTense_and_Evidential.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTense_and_Evidential.Presence'
+  N.levels : 2
   N.entries : 135
   N.languages : 135
   N.missing : 188
@@ -616,6 +654,7 @@ VInflTA.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTA.Presence'
+  N.levels : 2
   N.entries : 153
   N.languages : 153
   N.missing : 170
@@ -632,6 +671,7 @@ VInflTAM.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTAM.Presence'
+  N.levels : 2
   N.entries : 207
   N.languages : 207
   N.missing : 116
@@ -648,6 +688,7 @@ VInflTense.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTense.Presence'
+  N.levels : 2
   N.entries : 197
   N.languages : 197
   N.missing : 126
@@ -664,6 +705,7 @@ VInflTM.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTM.Presence'
+  N.levels : 2
   N.entries : 142
   N.languages : 142
   N.missing : 181
@@ -680,6 +722,7 @@ VInflValence.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflValence.Presence'
+  N.levels : 2
   N.entries : 137
   N.languages : 137
   N.missing : 186
@@ -696,6 +739,7 @@ VInflVersion.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflVersion.Presence'
+  N.levels : 2
   N.entries : 133
   N.languages : 133
   N.missing : 190

--- a/metadata/VInfl_counts_per_position.yaml
+++ b/metadata/VInfl_counts_per_position.yaml
@@ -8,6 +8,7 @@ VInflCatAndAgrIn.n:
   VariableType : 'data'
   DataType : 'count'
   VariantOf : 'VInflCatAndAgrIn.n'
+  N.levels : 4
   N.entries : 278
   N.languages : 278
   N.missing : 0
@@ -24,6 +25,7 @@ VInflCatAndAgrPost.n:
   VariableType : 'data'
   DataType : 'count'
   VariantOf : 'VInflCatAndAgrPost.n'
+  N.levels : 12
   N.entries : 278
   N.languages : 278
   N.missing : 0
@@ -40,6 +42,7 @@ VInflCatAndAgrPrae.n:
   VariableType : 'data'
   DataType : 'count'
   VariantOf : 'VInflCatAndAgrPrae.n'
+  N.levels : 12
   N.entries : 278
   N.languages : 278
   N.missing : 0
@@ -56,6 +59,7 @@ VInflCatAndAgrSimul.n:
   VariableType : 'data'
   DataType : 'count'
   VariantOf : 'VInflCatAndAgrSimul.n'
+  N.levels : 2
   N.entries : 278
   N.languages : 278
   N.missing : 0
@@ -72,6 +76,7 @@ VInflCatAndAgrSplit.n:
   VariableType : 'data'
   DataType : 'count'
   VariantOf : 'VInflCatAndAgrSplit.n'
+  N.levels : 6
   N.entries : 278
   N.languages : 278
   N.missing : 0

--- a/metadata/VInfl_macrocat_multiexponence.yaml
+++ b/metadata/VInfl_macrocat_multiexponence.yaml
@@ -8,6 +8,7 @@ VInflClassification.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflClassification.Pre.Presence'
+  N.levels : 1
   N.entries : 6
   N.languages : 6
   N.missing : 237
@@ -26,6 +27,7 @@ VInflEvidential.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflEvidential.Pre.Presence'
+  N.levels : 1
   N.entries : 22
   N.languages : 22
   N.missing : 221
@@ -44,6 +46,7 @@ VInflInter_clausal.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflInter_clausal.Pre.Presence'
+  N.levels : 1
   N.entries : 15
   N.languages : 15
   N.missing : 228
@@ -62,6 +65,7 @@ VInflNP_related.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflNP_related.Pre.Presence'
+  N.levels : 1
   N.entries : 5
   N.languages : 5
   N.missing : 238
@@ -80,6 +84,7 @@ VInflNumber.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflNumber.Pre.Presence'
+  N.levels : 2
   N.entries : 88
   N.languages : 87
   N.missing : 155
@@ -97,6 +102,7 @@ VInflOperators.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflOperators.Pre.Presence'
+  N.levels : 2
   N.entries : 90
   N.languages : 90
   N.missing : 153
@@ -115,6 +121,7 @@ VInflPerson.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPerson.Pre.Presence'
+  N.levels : 1
   N.entries : 6
   N.languages : 6
   N.missing : 237
@@ -132,6 +139,7 @@ VInflPragmatic.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPragmatic.Pre.Presence'
+  N.levels : 1
   N.entries : 46
   N.languages : 46
   N.missing : 197
@@ -150,6 +158,7 @@ VInflPragmatics.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPragmatics.Pre.Presence'
+  N.levels : 1
   N.entries : 7
   N.languages : 7
   N.missing : 236
@@ -168,6 +177,7 @@ VInflRole.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflRole.Pre.Presence'
+  N.levels : 1
   N.entries : 2
   N.languages : 2
   N.missing : 241
@@ -185,6 +195,7 @@ VInflTAM.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTAM.Pre.Presence'
+  N.levels : 2
   N.entries : 230
   N.languages : 227
   N.missing : 13
@@ -202,6 +213,7 @@ VInflValence.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflValence.Pre.Presence'
+  N.levels : 1
   N.entries : 124
   N.languages : 124
   N.missing : 119

--- a/metadata/VInfl_macrocat_postposed.yaml
+++ b/metadata/VInfl_macrocat_postposed.yaml
@@ -8,6 +8,7 @@ VInflClassification.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflClassification.Post.Presence'
+  N.levels : 2
   N.entries : 6
   N.languages : 6
   N.missing : 293
@@ -25,6 +26,7 @@ VInflEvidential.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflEvidential.Post.Presence'
+  N.levels : 1
   N.entries : 22
   N.languages : 22
   N.missing : 277
@@ -42,6 +44,7 @@ VInflInter_clausal.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflInter_clausal.Post.Presence'
+  N.levels : 2
   N.entries : 15
   N.languages : 15
   N.missing : 284
@@ -59,6 +62,7 @@ VInflNP_related.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflNP_related.Post.Presence'
+  N.levels : 2
   N.entries : 5
   N.languages : 5
   N.missing : 294
@@ -76,6 +80,7 @@ VInflNumber.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflNumber.Post.Presence'
+  N.levels : 2
   N.entries : 81
   N.languages : 75
   N.missing : 218
@@ -93,6 +98,7 @@ VInflOperators.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflOperators.Post.Presence'
+  N.levels : 2
   N.entries : 89
   N.languages : 89
   N.missing : 210
@@ -110,6 +116,7 @@ VInflPerson.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPerson.Post.Presence'
+  N.levels : 2
   N.entries : 6
   N.languages : 6
   N.missing : 293
@@ -127,6 +134,7 @@ VInflPragmatic.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPragmatic.Post.Presence'
+  N.levels : 2
   N.entries : 48
   N.languages : 46
   N.missing : 251
@@ -144,6 +152,7 @@ VInflPragmatics.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPragmatics.Post.Presence'
+  N.levels : 2
   N.entries : 7
   N.languages : 7
   N.missing : 292
@@ -161,6 +170,7 @@ VInflRole.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflRole.Post.Presence'
+  N.levels : 1
   N.entries : 2
   N.languages : 2
   N.missing : 297
@@ -178,6 +188,7 @@ VInflTAM.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTAM.Post.Presence'
+  N.levels : 2
   N.entries : 264
   N.languages : 223
   N.missing : 35
@@ -195,6 +206,7 @@ VInflValence.Post.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflValence.Post.Presence'
+  N.levels : 2
   N.entries : 136
   N.languages : 120
   N.missing : 163

--- a/metadata/VInfl_macrocat_preposed.yaml
+++ b/metadata/VInfl_macrocat_preposed.yaml
@@ -8,6 +8,7 @@ VInflClassification.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflClassification.Pre.Presence'
+  N.levels : 2
   N.entries : 6
   N.languages : 6
   N.missing : 297
@@ -25,6 +26,7 @@ VInflEvidential.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflEvidential.Pre.Presence'
+  N.levels : 1
   N.entries : 22
   N.languages : 22
   N.missing : 281
@@ -42,6 +44,7 @@ VInflInter_clausal.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflInter_clausal.Pre.Presence'
+  N.levels : 2
   N.entries : 15
   N.languages : 15
   N.missing : 288
@@ -59,6 +62,7 @@ VInflNP_related.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflNP_related.Pre.Presence'
+  N.levels : 2
   N.entries : 5
   N.languages : 5
   N.missing : 298
@@ -76,6 +80,7 @@ VInflNumber.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflNumber.Pre.Presence'
+  N.levels : 2
   N.entries : 95
   N.languages : 87
   N.missing : 208
@@ -93,6 +98,7 @@ VInflOperators.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflOperators.Pre.Presence'
+  N.levels : 2
   N.entries : 91
   N.languages : 91
   N.missing : 212
@@ -110,6 +116,7 @@ VInflPerson.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPerson.Pre.Presence'
+  N.levels : 2
   N.entries : 6
   N.languages : 6
   N.missing : 297
@@ -127,6 +134,7 @@ VInflPragmatic.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPragmatic.Pre.Presence'
+  N.levels : 2
   N.entries : 48
   N.languages : 46
   N.missing : 255
@@ -144,6 +152,7 @@ VInflPragmatics.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPragmatics.Pre.Presence'
+  N.levels : 2
   N.entries : 7
   N.languages : 7
   N.missing : 296
@@ -161,6 +170,7 @@ VInflRole.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflRole.Pre.Presence'
+  N.levels : 1
   N.entries : 2
   N.languages : 2
   N.missing : 301
@@ -178,6 +188,7 @@ VInflTAM.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTAM.Pre.Presence'
+  N.levels : 2
   N.entries : 276
   N.languages : 227
   N.missing : 27
@@ -195,6 +206,7 @@ VInflValence.Pre.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflValence.Pre.Presence'
+  N.levels : 2
   N.entries : 142
   N.languages : 124
   N.missing : 161

--- a/metadata/VInfl_macrocategories.yaml
+++ b/metadata/VInfl_macrocategories.yaml
@@ -8,6 +8,7 @@ VInflClassification.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflClassification.Presence'
+  N.levels : 2
   N.entries : 136
   N.languages : 136
   N.missing : 187
@@ -24,6 +25,7 @@ VInflEvidential.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflEvidential.Presence'
+  N.levels : 2
   N.entries : 161
   N.languages : 161
   N.missing : 162
@@ -40,6 +42,7 @@ VInflInter_clausal.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflInter_clausal.Presence'
+  N.levels : 2
   N.entries : 150
   N.languages : 150
   N.missing : 173
@@ -56,6 +59,7 @@ VInflNP_related.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflNP_related.Presence'
+  N.levels : 2
   N.entries : 138
   N.languages : 138
   N.missing : 185
@@ -72,6 +76,7 @@ VInflNumber.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflNumber.Presence'
+  N.levels : 2
   N.entries : 199
   N.languages : 199
   N.missing : 124
@@ -88,6 +93,7 @@ VInflOperators.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflOperators.Presence'
+  N.levels : 2
   N.entries : 222
   N.languages : 222
   N.missing : 101
@@ -104,6 +110,7 @@ VInflPerson.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPerson.Presence'
+  N.levels : 2
   N.entries : 135
   N.languages : 135
   N.missing : 188
@@ -120,6 +127,7 @@ VInflPragmatic.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPragmatic.Presence'
+  N.levels : 2
   N.entries : 166
   N.languages : 166
   N.missing : 157
@@ -136,6 +144,7 @@ VInflPragmatics.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflPragmatics.Presence'
+  N.levels : 2
   N.entries : 140
   N.languages : 140
   N.missing : 183
@@ -152,6 +161,7 @@ VInflRole.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflRole.Presence'
+  N.levels : 2
   N.entries : 133
   N.languages : 133
   N.missing : 190
@@ -168,6 +178,7 @@ VInflTAM.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflTAM.Presence'
+  N.levels : 2
   N.entries : 319
   N.languages : 319
   N.missing : 4
@@ -184,6 +195,7 @@ VInflValence.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'VInflValence.Presence'
+  N.levels : 2
   N.entries : 224
   N.languages : 224
   N.missing : 99

--- a/metadata/Valence_classes.yaml
+++ b/metadata/Valence_classes.yaml
@@ -155,6 +155,7 @@ ValClassID:
   VariableType : 'register'
   DataType : 'count'
   VariantOf : 'ValClassID'
+  N.levels : 925
   N.entries : 3415
   N.languages : 218
   N.missing : 0

--- a/metadata/Valence_classes_per_language.yaml
+++ b/metadata/Valence_classes_per_language.yaml
@@ -7,6 +7,7 @@ ValClassesWithVerbsOfType.ability.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.ability.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -22,6 +23,7 @@ ValClassesWithVerbsOfType.achieve.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.achieve.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -37,6 +39,7 @@ ValClassesWithVerbsOfType.activity.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.activity.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -52,6 +55,7 @@ ValClassesWithVerbsOfType.appearance_disappearance.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.appearance_disappearance.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -67,6 +71,7 @@ ValClassesWithVerbsOfType.aspectual.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.aspectual.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -82,6 +87,7 @@ ValClassesWithVerbsOfType.assuming_position.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.assuming_position.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -97,6 +103,7 @@ ValClassesWithVerbsOfType.attempt.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.attempt.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -112,6 +119,7 @@ ValClassesWithVerbsOfType.bodily_emission.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.bodily_emission.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -127,6 +135,7 @@ ValClassesWithVerbsOfType.caused_motion.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.caused_motion.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -142,6 +151,7 @@ ValClassesWithVerbsOfType.change_of_possession.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.change_of_possession.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -157,6 +167,7 @@ ValClassesWithVerbsOfType.change_of_state.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.change_of_state.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -172,6 +183,7 @@ ValClassesWithVerbsOfType.cognition.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.cognition.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -187,6 +199,7 @@ ValClassesWithVerbsOfType.combine_attach.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.combine_attach.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -202,6 +215,7 @@ ValClassesWithVerbsOfType.communication.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.communication.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -217,6 +231,7 @@ ValClassesWithVerbsOfType.creation_transformation.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.creation_transformation.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -232,6 +247,7 @@ ValClassesWithVerbsOfType.desideration.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.desideration.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -247,6 +263,7 @@ ValClassesWithVerbsOfType.destroy.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.destroy.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -262,6 +279,7 @@ ValClassesWithVerbsOfType.diseases_and_bodily_states.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.diseases_and_bodily_states.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -277,6 +295,7 @@ ValClassesWithVerbsOfType.emotion.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.emotion.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -292,6 +311,7 @@ ValClassesWithVerbsOfType.existence.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.existence.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -307,6 +327,7 @@ ValClassesWithVerbsOfType.fail.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.fail.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -322,6 +343,7 @@ ValClassesWithVerbsOfType.fight.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.fight.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -337,6 +359,7 @@ ValClassesWithVerbsOfType.grooming.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.grooming.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -352,6 +375,7 @@ ValClassesWithVerbsOfType.happening.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.happening.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -367,6 +391,7 @@ ValClassesWithVerbsOfType.help.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.help.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -382,6 +407,7 @@ ValClassesWithVerbsOfType.hide.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.hide.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -397,6 +423,7 @@ ValClassesWithVerbsOfType.hit.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.hit.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -412,6 +439,7 @@ ValClassesWithVerbsOfType.hold_keep.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.hold_keep.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -427,6 +455,7 @@ ValClassesWithVerbsOfType.hurt.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.hurt.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -442,6 +471,7 @@ ValClassesWithVerbsOfType.influence_cause.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.influence_cause.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -457,6 +487,7 @@ ValClassesWithVerbsOfType.ingestion.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.ingestion.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -472,6 +503,7 @@ ValClassesWithVerbsOfType.judge.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.judge.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -487,6 +519,7 @@ ValClassesWithVerbsOfType.kill.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.kill.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -502,6 +535,7 @@ ValClassesWithVerbsOfType.lose.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.lose.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -517,6 +551,7 @@ ValClassesWithVerbsOfType.laugh_wink.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.laugh_wink.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -534,6 +569,7 @@ ValClassesWithVerbsOfType.M_contact.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.M_contact.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -553,6 +589,7 @@ ValClassesWithVerbsOfType.M_effective_action.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.M_effective_action.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -571,6 +608,7 @@ ValClassesWithVerbsOfType.M_emotion.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.M_emotion.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -589,6 +627,7 @@ ValClassesWithVerbsOfType.M_motion.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.M_motion.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -607,6 +646,7 @@ ValClassesWithVerbsOfType.M_other.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.M_other.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -626,6 +666,7 @@ ValClassesWithVerbsOfType.M_perception_cognition.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.M_perception_cognition.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -644,6 +685,7 @@ ValClassesWithVerbsOfType.M_pursuit.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.M_pursuit.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -662,6 +704,7 @@ ValClassesWithVerbsOfType.M_sensation.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.M_sensation.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -678,6 +721,7 @@ ValClassesWithVerbsOfType.measure.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.measure.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -693,6 +737,7 @@ ValClassesWithVerbsOfType.modality.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.modality.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -708,6 +753,7 @@ ValClassesWithVerbsOfType.motion.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.motion.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -723,6 +769,7 @@ ValClassesWithVerbsOfType.name.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.name.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -738,6 +785,7 @@ ValClassesWithVerbsOfType.necessity.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.necessity.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -753,6 +801,7 @@ ValClassesWithVerbsOfType.obligation.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.obligation.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -768,6 +817,7 @@ ValClassesWithVerbsOfType.perception.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.perception.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -783,6 +833,7 @@ ValClassesWithVerbsOfType.persuit.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.persuit.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -798,6 +849,7 @@ ValClassesWithVerbsOfType.possession.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.possession.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -813,6 +865,7 @@ ValClassesWithVerbsOfType.push_pull.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.push_pull.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -828,6 +881,7 @@ ValClassesWithVerbsOfType.put_pour_spray_load_fill.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.put_pour_spray_load_fill.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -843,6 +897,7 @@ ValClassesWithVerbsOfType.quality.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.quality.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -858,6 +913,7 @@ ValClassesWithVerbsOfType.remove_wipe_clear.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.remove_wipe_clear.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -873,6 +929,7 @@ ValClassesWithVerbsOfType.scent_emission.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.scent_emission.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -888,6 +945,7 @@ ValClassesWithVerbsOfType.seem.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.seem.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -903,6 +961,7 @@ ValClassesWithVerbsOfType.send_carry_bring_take.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.send_carry_bring_take.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -918,6 +977,7 @@ ValClassesWithVerbsOfType.sensation.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.sensation.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -933,6 +993,7 @@ ValClassesWithVerbsOfType.separate_disassemble.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.separate_disassemble.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -948,6 +1009,7 @@ ValClassesWithVerbsOfType.sleep.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.sleep.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -963,6 +1025,7 @@ ValClassesWithVerbsOfType.social_interaction.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.social_interaction.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -978,6 +1041,7 @@ ValClassesWithVerbsOfType.sound_emission.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.sound_emission.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -993,6 +1057,7 @@ ValClassesWithVerbsOfType.spatial_position.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.spatial_position.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -1008,6 +1073,7 @@ ValClassesWithVerbsOfType.spread_apply.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.spread_apply.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -1023,6 +1089,7 @@ ValClassesWithVerbsOfType.touch.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.touch.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0
@@ -1038,6 +1105,7 @@ ValClassesWithVerbsOfType.use.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'ValClassesWithVerbsOfType.use.Presence'
+  N.levels : 2
   N.entries : 208
   N.languages : 208
   N.missing : 0

--- a/metadata/Word_domains.yaml
+++ b/metadata/Word_domains.yaml
@@ -37,6 +37,7 @@ MphmTypesInCohDomain.prop:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'MphmTypesInCohDomain'
+  N.levels : 21
   N.entries : 879
   N.languages : 76
   N.missing : 2
@@ -53,6 +54,7 @@ MphmTypesInCohPrefixDomain.prop:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'MphmTypesInCohDomain'
+  N.levels : 15
   N.entries : 877
   N.languages : 76
   N.missing : 4
@@ -81,6 +83,7 @@ MphmTypesInCohSuffixDomain.prop:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'MphmTypesInCohDomain'
+  N.levels : 14
   N.entries : 877
   N.languages : 76
   N.missing : 4
@@ -109,6 +112,7 @@ MphmTypesInCohStemDomain.prop:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'MphmTypesInCohDomain'
+  N.levels : 7
   N.entries : 877
   N.languages : 76
   N.missing : 4
@@ -167,6 +171,7 @@ MphmTypesInCohDomain.binned77:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'MphmTypesInCohDomain'
+  N.levels : 76
   N.entries : 877
   N.languages : 76
   N.missing : 4
@@ -183,6 +188,7 @@ CoherentEncliticBoundary.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CoherentEncliticBoundary'
+  N.levels : 2
   N.entries : 518
   N.languages : 55
   N.missing : 363
@@ -196,6 +202,7 @@ CoherentEnclEnclBoundary.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CoherentEnclEnclBoundary'
+  N.levels : 2
   N.entries : 589
   N.languages : 55
   N.missing : 292
@@ -246,6 +253,7 @@ MphmTypesInCohDomain.multistem.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'MphmTypesInCohDomain'
+  N.levels : 2
   N.entries : 877
   N.languages : 76
   N.missing : 4
@@ -2880,6 +2888,7 @@ CoherentPrefixBoundary.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CoherentPrefixBoundary'
+  N.levels : 2
   N.entries : 722
   N.languages : 62
   N.missing : 159
@@ -2896,6 +2905,7 @@ CoherentPrefixPrefixBoundary.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CoherentPrefixPrefixBoundary'
+  N.levels : 2
   N.entries : 726
   N.languages : 62
   N.missing : 155
@@ -2912,6 +2922,7 @@ CoherentPrefixStemBoundary.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CoherentPrefixStemBoundary'
+  N.levels : 2
   N.entries : 727
   N.languages : 62
   N.missing : 154
@@ -2928,6 +2939,7 @@ CoherentProclBoundary.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CoherentProclBoundary'
+  N.levels : 2
   N.entries : 313
   N.languages : 26
   N.missing : 568
@@ -2941,6 +2953,7 @@ CoherentProclPrefixBoundary.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CoherentProclPrefixBoundary'
+  N.levels : 2
   N.entries : 284
   N.languages : 23
   N.missing : 597
@@ -2957,6 +2970,7 @@ CoherentProclProcliticBoundary.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CoherentProclProcliticBoundary'
+  N.levels : 2
   N.entries : 313
   N.languages : 26
   N.missing : 568
@@ -2973,6 +2987,7 @@ CoherentProclStemBoundary.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CoherentProclStemBoundary'
+  N.levels : 2
   N.entries : 315
   N.languages : 26
   N.missing : 566
@@ -3022,6 +3037,7 @@ MphmTypesInCohDomain.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'MphmTypesInCohDomain'
+  N.levels : 8
   N.entries : 877
   N.languages : 76
   N.missing : 4
@@ -3038,6 +3054,7 @@ MphmTypesInCohPrefixDomain.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'MphmTypesInCohDomain'
+  N.levels : 7
   N.entries : 875
   N.languages : 76
   N.missing : 6
@@ -3054,6 +3071,7 @@ MphmTypesInCohSuffixDomain.n:
   VariableType : 'data'
   DataType : 'ratio'
   VariantOf : 'MphmTypesInCohDomain'
+  N.levels : 6
   N.entries : 875
   N.languages : 76
   N.missing : 6
@@ -3070,6 +3088,7 @@ CoherentStemBoundary.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CoherentStemBoundary'
+  N.levels : 2
   N.entries : 839
   N.languages : 75
   N.missing : 42
@@ -3086,6 +3105,7 @@ CoherentStemEnclBoundary.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CoherentStemEnclBoundary'
+  N.levels : 2
   N.entries : 592
   N.languages : 55
   N.missing : 289
@@ -3102,6 +3122,7 @@ CoherentStemEndoclBoundary.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CoherentStemEndoclBoundary'
+  N.levels : 2
   N.entries : 8
   N.languages : 1
   N.missing : 873
@@ -3118,6 +3139,7 @@ CoherentStemInfixBoundary.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CoherentStemInfixBoundary'
+  N.levels : 2
   N.entries : 104
   N.languages : 8
   N.missing : 777
@@ -3131,6 +3153,7 @@ CoherentStemSuffixBoundary.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CoherentStemSuffixBoundary'
+  N.levels : 2
   N.entries : 759
   N.languages : 68
   N.missing : 122
@@ -3148,6 +3171,7 @@ CohesionPattern.stress.Presence:
   VariableType : 'condition'
   DataType : 'logical'
   VariantOf : 'CohesionPattern'
+  N.levels : 2
   N.entries : 833
   N.languages : 74
   N.missing : 48
@@ -3162,6 +3186,7 @@ CohPatternStructurePreserving.Presence:
   VariableType : 'condition'
   DataType : 'logical'
   VariantOf : 'CohPatternOutputOrigin'
+  N.levels : 2
   N.entries : 805
   N.languages : 70
   N.missing : 76
@@ -3175,6 +3200,7 @@ CoherentSuffixBoundary.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CoherentSuffixBoundary'
+  N.levels : 2
   N.entries : 731
   N.languages : 68
   N.missing : 150
@@ -3191,6 +3217,7 @@ CoherentSuffixEnclBoundary.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CoherentSuffixEnclBoundary'
+  N.levels : 2
   N.entries : 532
   N.languages : 51
   N.missing : 349
@@ -3207,6 +3234,7 @@ CoherentSuffixSuffixBoundary.Presence:
   VariableType : 'data'
   DataType : 'logical'
   VariantOf : 'CoherentSuffixSuffixBoundary'
+  N.levels : 2
   N.entries : 740
   N.languages : 68
   N.missing : 141


### PR DESCRIPTION
According to [readme.md](https://github.com/autotyp/autotyp-data/blob/master/readme.md), `N.levels` is mandatory, yet it is missing in 627 variable descriptions in `metdata/*.yaml`. This PR fills them from [metadata_overview.csv](https://github.com/autotyp/autotyp-data/blob/master/metadata_overview.csv) (assuming correctness of the file).